### PR TITLE
Fix typo: Remove superfluous "the" in about text

### DIFF
--- a/template/about-global.phtml
+++ b/template/about-global.phtml
@@ -30,7 +30,7 @@
 	<hr>
 	<a name="en"></a>
 
-	<p>We try to record and stream events (lectures, lightning talks, podiums, etc) of the conferences we are present at. We exclude events where the speaker opts out. We provide the the following services to our users.</p>
+	<p>We try to record and stream events (lectures, lightning talks, podiums, etc) of the conferences we are present at. We exclude events where the speaker opts out. We provide the following services to our users.</p>
 
 	<h2>At the conference</h2>
 	<p>At conferences were eventphone <a href="https://eventphone.de">Eventphone</a> is offering their services, we provide audio feeds via the DECT and GSM network. At conferences where live translation is available, these feeds are also provided this way. Have a look at the <a href="https://eventphone.de/guru2/phonebook">GURU</a> to find out which numbers are used.</p>


### PR DESCRIPTION
All said.Thanks for the great service at 32c3. Good show.