### PR TITLE
relive: handle missing scrub thumbs correctly

### DIFF
--- a/assets/js/lustiges-script.js
+++ b/assets/js/lustiges-script.js
@@ -21,6 +21,18 @@ $(function() {
 
 	var $relivePlayer = $('body.relive-player .video-wrap');
 	if($relivePlayer.length > 0) {
+		var sprites = [];
+
+		if($relivePlayer.data("sprites")) {
+			sprites = ClapprThumbnailsPlugin.buildSpriteConfig(
+				$relivePlayer.data("sprites"),
+				$relivePlayer.data("sprites-n"),
+				160, 90,
+				$relivePlayer.data("sprites-cols"),
+				$relivePlayer.data("sprites-interval")
+			);
+		}
+
 		var player = new Clappr.Player({
 			baseUrl: 'assets/clapprio/',
 			plugins: {
@@ -34,13 +46,7 @@ $(function() {
 			scrubThumbnails: {
 				backdropHeight: 64,
 				spotlightHeight: 84,
-				thumbs: ClapprThumbnailsPlugin.buildSpriteConfig(
-					$relivePlayer.data("sprites"),
-					$relivePlayer.data("sprites-n"),
-					160, 90,
-					$relivePlayer.data("sprites-cols"),
-					$relivePlayer.data("sprites-interval")
-				),
+				thumbs: sprites
 			},
 			events: {
 				onReady: function() {


### PR DESCRIPTION
Previously, when relive didn't supply a sprites file to the player, we'd
simply pass undefined into buildSpriteConfig, which only worked because
of the way the arguments are handled internally in that function, but
does not represent a proper use of the plugin's API.

Instead, we now manually check whether relive has supplied a sprites
file and explicitly pass an empty thumbs array to the plugin in such a
case.