### PR TITLE
Bring footer on top of overlay with current time

### DIFF
--- a/configs/conferences/34c3/main.less
+++ b/configs/conferences/34c3/main.less
@@ -334,7 +334,7 @@ footer {
 	color: @dark-grey;
 
 	margin-top: 64px;
-
+	z-index: 6;
 
 	a {
 		color: @lighter-grey;


### PR DESCRIPTION
Before this change the grey overlay of the current time is on top of the footer when scrolling. With this change the footer should be always on top.