### PR TITLE
make the background image cover the complete screen

### DIFF
--- a/configs/conferences/occon18/main.less
+++ b/configs/conferences/occon18/main.less
@@ -4,6 +4,7 @@ body {
         background: url(bg.jpg) no-repeat top left;
         background-attachment: fixed;
         background-position: 0px 50px;
+        background-size: cover;
 }
 
 .logo {


### PR DESCRIPTION
even on bigger monitors

vorher:
![bildschirmfoto 2018-09-17 um 11 48 06](https://user-images.githubusercontent.com/142237/45616402-a9efc780-ba6f-11e8-8d52-00b35d621de0.png)

nachher:
![bildschirmfoto 2018-09-17 um 11 48 21](https://user-images.githubusercontent.com/142237/45616407-aceab800-ba6f-11e8-8bfa-8845152fb8d8.png)
