### PR TITLE
Change play button color

### DIFF
--- a/assets/css/_relive.less
+++ b/assets/css/_relive.less
@@ -41,6 +41,11 @@ body.relive-player {
 				max-width: 100%;
 				height: auto !important;
 			}
+			
+			.player-poster[data-poster] .play-wrapper[data-poster] svg path {
+				fill: #ccc; 
+			}
+			
 		}
 	}
 

--- a/assets/css/_relive.less
+++ b/assets/css/_relive.less
@@ -42,8 +42,14 @@ body.relive-player {
 				height: auto !important;
 			}
 			
+			//Change play button color from #FFF to grey.
 			.player-poster[data-poster] .play-wrapper[data-poster] svg path {
 				fill: #ccc; 
+			}
+			
+			//Change loading indicator color from #FFF to grey.
+			.spinner-three-bounce[data-spinner] > div {
+				background-color: #ccc;
 			}
 			
 		}


### PR DESCRIPTION
Plain white play button is unfortunate with talks that show slides with white background

Before:
![firefox_2018-12-29_22-32-21](https://user-images.githubusercontent.com/3768165/50542264-b086f280-0bb9-11e9-8bf7-db84d70ded98.png)
After:
![firefox_2018-12-29_22-32-30](https://user-images.githubusercontent.com/3768165/50542265-b54ba680-0bb9-11e9-8332-fa751affe19c.png)


I don't know if this is the right place and method to patch that css, so please don't just merge this, I don't know what I'm doing.

Source is clappr.js Line 31488
`.player-poster[data-poster] .play-wrapper[data-poster] svg path {\n        fill: #fff; }`

Should also change the color of the loading indicator. I don't do that yet.
The loading indicator is `.spinner-three-bounce[data-spinner] > div` in clappr.js Line 30868. I'll try to add that to this PR, but still don't really know what I'm doing.