### PR TITLE
Fix roomfilter issue

### DIFF
--- a/configs/conferences/cpu19/config.php
+++ b/configs/conferences/cpu19/config.php
@@ -216,11 +216,11 @@ $CONFIG['SCHEDULE'] = array(
 	'URL' => 'https://pretalx.chaos-party-ulm.de/cpu19/schedule/export/schedule.xml',
 
 	/**
-	     * Nur die angegebenen Räume aus dem Fahrplan beachten
-	     *
+	 * Nur die angegebenen Räume aus dem Fahrplan beachten
+	 *
 	 * Wird diese Zeile auskommentiert, werden alle Räume angezeigt
 	 */
-	//'ROOMFILTER' => array('H20'),
+	'ROOMFILTER' => array('H20'),
 
 	/**
 	 * Skalierung der Programm-Vorschau in Sekunden pro Pixel

--- a/model/Schedule.php
+++ b/model/Schedule.php
@@ -112,8 +112,13 @@ class Schedule
 				}
 			}
 
-			$day['start'] = $daystart;
-			$day['end'] = $dayend;
+			if((int)$daystart >= PHP_INT_MAX) {
+				$day['start'] = strtotime((string)$day['start']);
+				$day['end'] = strtotime((string)$day['end']);
+			} else {
+				$day['start'] = $daystart;
+				$day['end'] = $dayend;
+			}
 		}
 
 


### PR DESCRIPTION
If `SCHEDULE.ROOMFILTER` is used and in the schedule is one day where no events are to be displayed because of the roomfilter, a value ~PHP_INT_MAX is used. This is overriden by overriding `$daystart` and `$dayend` with start and end of the schedule day.

Better implementations or recommendations for fix welcome. I'm not that PHP expert ;)