### PR TITLE
Preserve schedule timezones and show current time + event timezone on the page

### DIFF
--- a/assets/css/_schedule.less
+++ b/assets/css/_schedule.less
@@ -16,19 +16,21 @@ body .schedule {
 
 	.now {
 		position: absolute;
-		left: 0;
-		width: 150px;
-		height: 100%;
-		background-color: @schedule-now-bg;
-		font-size: 14px;
 		pointer-events: none;
-
+		height: 100%;
+		display: flex;
+		left: 0;
 		z-index: 5;
 
-		span {
-			display: block;
-			position: absolute;
-			right: -28px;
+		.overlay {
+			width: 150px;
+			height: 100%;
+			background-color: @schedule-now-bg;
+		}
+
+		.label {
+			font-size: 14px;
+			padding-left: 5px;
 			color: @schedule-now;
 		}
 	}
@@ -50,7 +52,7 @@ body .schedule {
 
 		.inner {
 			display: block;
-			padding: 10px;
+			padding: 15px;
 			height: 100%;
 		}
 

--- a/assets/css/_structure.less
+++ b/assets/css/_structure.less
@@ -55,6 +55,11 @@ nav {
 		}
 	}
 
+	.navbar-time {
+		line-height: 27px;
+		padding: 10px 10px;
+	}
+
 	.button-wrapper > .btn {
 		width: 40px;
 	}

--- a/template/assemblies/header.phtml
+++ b/template/assemblies/header.phtml
@@ -22,6 +22,12 @@
 				<span class="fa fa-info"></span>
 			</a>
 		</div>
+
+		<? if(isset($room) && $room->hasSchedule()): ?>
+			<div class="navbar-right navbar-time">
+				Current Time
+			</div>
+		<? endif ?>
 	</div>
 </nav>
 

--- a/template/assemblies/schedule.phtml
+++ b/template/assemblies/schedule.phtml
@@ -1,10 +1,14 @@
 <div class="schedule scroll-container">
 	<div class="scroll-element">
-		<div class="now"><span>now</span></div>
+		<? $totalWidth = round($schedule->getDurationSum() / $schedule->getScale()) ?>
+		<div class="now" style="width: <?= h($totalWidth) ?>px">
+			<div class="overlay"></div>
+			<div class="label">now</div>
+		</div>
 		<? $rooms = $schedule->getSchedule() ?>
 		<? foreach($rooms as $roomname => $events): ?>
 			<? $scheduleRoom = $schedule->getMappedRoom($roomname) ?>
-			<div class="room <? if(isset($room) && $roomname == $room->getScheduleName()): ?>highlight<? endif ?>" style="width: <?=round($schedule->getDurationSum() / $schedule->getScale())?>px">
+			<div class="room <? if(isset($room) && $roomname == $room->getScheduleName()): ?>highlight<? endif ?>" style="width: <?= h($totalWidth) ?>px">
 				<? $fromstart = 0; ?>
 				<? foreach($events as $event): ?>
 					<div
@@ -12,6 +16,7 @@
 						style="width: <?=h(round($event['duration'] / $schedule->getScale()))?>px; left: <?=h(round($fromstart / $schedule->getScale()))?>px"
 						data-start="<?=intval($event['start'])?>"
 						data-end="<?=intval($event['end'])?>"
+						data-offset="<?=intval($event['offset']/60)?>"
 					>
 						<? $fromstart += $event['duration'] ?>
 						<? if($scheduleRoom): ?>
@@ -42,9 +47,9 @@
 
 							<? else: ?>
 								<? if($event['duration'] > 10*60): /* only display when event is longer as 10 minutes */ ?>
-									<h4><?=h(strftime('%H:%M', $event['start']))?>
+									<h4><?=h($event['tstart'])?>
 										&ndash;
-										<?=h(strftime('%H:%M', $event['end']))?>
+										<?=h($event['tend'])?>
 										&nbsp;in&nbsp;
 										<?=h($scheduleRoom ? $scheduleRoom->getDisplayShort() : $roomname) ?>
 									</h4>


### PR DESCRIPTION
Mostly fixes #87 

Adds a current time+timezone display in the upper right corner, shows the current time on the "now" slider of the schedule and preserves the timezone of the original event schedule.

The result looks like this:
![Screenshot_2020-07-12 Circus tent – Klimacamp Leipziger Land 2020 Streaming](https://user-images.githubusercontent.com/1429641/87254030-d912cc80-c47f-11ea-9bcd-60e4c2147d9f.png)


However this introduces some changes to getSchedule().

@saerdnaer, @dedeibel: Can we add new fields to the streams-api? Or should I clean up the output so it matches the old one?