### PR TITLE
Hashtag für Sendezentrum geändert

### DIFF
--- a/configs/conferences/rc3/config.php
+++ b/configs/conferences/rc3/config.php
@@ -743,8 +743,8 @@ $CONFIG['ROOMS'] = array(
 			),
 			'TWITTER' => true,
 			'TWITTER_CONFIG' => array(
-				'DISPLAY' => '#rC3sendezentrum @ mastodon/twitter',
-				'TEXT'    => '#rC3sendezentrum',
+				'DISPLAY' => '#rC3sz @ mastodon/twitter',
+				'TEXT'    => '#rC3sz',
 			),
 	),
 	'wikipaka' => array(


### PR DESCRIPTION
Hashtag für Sendezentrum von #rC3sendezentrum zu #rC3sz geändert