### PR TITLE
fix optout label

### DIFF
--- a/template/assemblies/schedule.phtml
+++ b/template/assemblies/schedule.phtml
@@ -55,7 +55,7 @@
 									</h4>
 								<? endif ?>
 								<h3 title="<?=$event['title']?>">
-									<?=h($event['title'])?><? if (@$event['optout']): ?><i> (no stream)</i><? endif ?>
+									<?=h($event['title'])?><? if (@$event['optout']): ?><i> (no recording)</i><? endif ?>
 								</h3>
 								<? if(! empty(trim($event['speaker']))): ?>
 									<h5>by&nbsp;<?=h($event['speaker'])?></h5>


### PR DESCRIPTION
The optout is for recording, not for livestreaming of the event:

https://github.com/voc/streaming-website/blob/2cce170626ed4b92cebe6af7a6b7f8ebd159108f/model/Schedule.php#L42-L47

It's confusing to see livestreamed events with a "no stream" label.