### PR TITLE
Update rC3 2021 Chaosstudio Hamburg config

### DIFF
--- a/configs/conferences/rc3/config.php
+++ b/configs/conferences/rc3/config.php
@@ -129,7 +129,7 @@ $CONFIG['OVERVIEW'] = array(
 			'cbase',
 			'cwtv',
 			'r3s',
-			'chaosstudio-hamburg',
+			'csh',
 			'chaoszone',
 			'fem',
 			'franconiannet',
@@ -389,10 +389,10 @@ $CONFIG['ROOMS'] = array(
 				'TEXT'    => '#rC3chaoszone',
 			),
 	),
-	'chaosstudio-hamburg' => array(
+	'csh' => array(
 			'DISPLAY' => 'ChaosStudio Hamburg',
 			'DISPLAY_SHORT' => 'CSH',
-			'STREAM' => 'chaosstudio-hamburg',
+			'STREAM' => 'csh',
 			'PREVIEW' => true,
 			'TRANSLATION' => [
 				['endpoint' => 'translated',   'label' => 'Translated1'],


### PR DESCRIPTION
Stream ID and slug is "csh" this year instead of "chaosstudio-hamburg". IRC and twitter are correct.