### PR TITLE
Feature/info

### DIFF
--- a/configs/conferences/rc3/config.php
+++ b/configs/conferences/rc3/config.php
@@ -214,6 +214,14 @@ $CONFIG['TWITTER'] = array(
  */
 $CONFIG['EMBED'] = true;
 
+/**
+ * Globaler Schalter für die Raum Infos
+ *
+ * Wird diese Zeile auskommentiert oder auf False gesetzt, werden alle
+ * Raum Infos deaktiviert.
+ */
+$CONFIG['INFO'] = true;
+
 
 /**
  * Liste der Räume (= Audio & Video Produktionen, also auch DJ-Sets oä.)
@@ -256,6 +264,7 @@ $CONFIG['ROOMS'] = array(
 				'DISPLAY' => '#rC3lounge @ mastodon/twitter',
 				'TEXT'    => '#rC3lounge',
 			),
+			'INFO' => '',
 	),
 	'abchillgleis' => array(
 			 'DISPLAY' => 'Abchillgleis',

--- a/model/Relive.php
+++ b/model/Relive.php
@@ -31,7 +31,11 @@ class Relive
 
 	public function getJsonCache()
 	{
-		return sprintf('/tmp/relive-cache-%s.json', $this->getConference()->getSlug());
+		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+			return sprintf('C:\tmp\relive-cache-%s.json', $this->getConference()->getSlug());
+		} else {
+			return sprintf('/tmp/relive-cache-%s.json', $this->getConference()->getSlug());
+		}
 	}
 
 	public function getTalks()

--- a/model/Room.php
+++ b/model/Room.php
@@ -183,7 +183,7 @@ class Room
 	}
 
 	public function hasInfo() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.INFO') && $this->getConference()->get('EMBED');
+		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.INFO') && $this->getConference()->get('INFO');
 	}
 
 	public function getInfo() {

--- a/model/Room.php
+++ b/model/Room.php
@@ -173,7 +173,6 @@ class Room
 		);
 	}
 
-
 	public function hasChat() {
 		return $this->hasTwitter() || $this->hasIrc() || $this->hasWebchat();
 	}
@@ -183,7 +182,14 @@ class Room
 		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.EMBED') && $this->getConference()->get('EMBED');
 	}
 
+	public function hasInfo() {
+		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.INFO') && $this->getConference()->get('EMBED');
+	}
 
+	public function getInfo() {
+		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.INFO');
+	}
+	
 	public function hasSdVideo() {
 		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.SD_VIDEO');
 	}

--- a/model/Schedule.php
+++ b/model/Schedule.php
@@ -319,7 +319,11 @@ class Schedule
 
 	public function getScheduleCache()
 	{
-		return sprintf('/tmp/schedule-cache-%s.xml', $this->getConference()->getSlug());
+		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+			return sprintf('C:\tmp\schedule-cache-%s.xml', $this->getConference()->getSlug());
+		} else {
+			return sprintf('/tmp/schedule-cache-%s.xml', $this->getConference()->getSlug());
+		}
 	}
 
 

--- a/template/assemblies/info.phtml
+++ b/template/assemblies/info.phtml
@@ -1,0 +1,10 @@
+<? if($room->hasInfo()): ?>
+    <div class="col-xs-12">
+		<h3>Info about <?=h($stream->getDisplay())?></h3>
+	</div>
+    <div class="col-sm-12">
+        <p>
+		    <?=$room->getInfo()?>
+	    </p>
+    </div>
+<? endif ?>

--- a/template/room.phtml
+++ b/template/room.phtml
@@ -47,6 +47,11 @@
 				<a href="#embed" role="tab" data-toggle="tab">Embed</a>
 			</li>
 		<? endif ?>
+		<? if($room->hasInfo()): ?>
+			<li>
+				<a href="#info" role="tab" data-toggle="tab">Info</a>
+			</li>
+		<? endif ?>
 	</ul>
 
 	<div class="functions-wrap tab-content">
@@ -72,6 +77,11 @@
 		<? if($room->hasEmbed()): ?>
 			<div role="tabpanel" class="tab-pane" id="embed">
 				<? require("$assemblies/embed-form.phtml") ?>
+			</div>
+		<? endif ?>
+		<? if($room->hasInfo()): ?>
+			<div role="tabpanel" class="tab-pane" id="info">
+				<? require("$assemblies/info.phtml") ?>
 			</div>
 		<? endif ?>
 	</div>


### PR DESCRIPTION
This adds a new tab per room, which can have more details about the room.
Good for conferences where you have assemblies like rc3.
There are 2 new config options:

`$CONFIG['INFO'] = true;`

Which enables/disables the feature globally like with the Embed option.

`$CONFIG['ROOMS'].<SLUG>.INFO`

This has the info details, which can include HTML tags for formatting

![firefox_fvLiNDIQkg](https://user-images.githubusercontent.com/706758/147025091-e6cfc62e-1fcd-4722-86ff-149a73d763da.png)
 