### PR TITLE
rc3_21: update about:future slug and shortname

### DIFF
--- a/configs/conferences/rc3/config.php
+++ b/configs/conferences/rc3/config.php
@@ -473,8 +473,8 @@ $CONFIG['ROOMS'] = array(
 	),
 	'aboutfuture' => array(
 		'DISPLAY' => 'about:future',
-		'DISPLAY_SHORT' => 'hacc/a:f',
-		'STREAM' => 'hacc',
+		'DISPLAY_SHORT' => 'a:f',
+		'STREAM' => 'aboutfuture',
 		'PREVIEW' => true,
 		'TRANSLATION' => [
 		],


### PR DESCRIPTION
This patch updates to our new slug, so our stream can reach the test site
It also removes the hacc reference because #drama