### PR TITLE
Display current time on same row as navigation buttons on narrow screens

### DIFF
--- a/assets/css/_structure.less
+++ b/assets/css/_structure.less
@@ -55,6 +55,10 @@ nav {
 		}
 	}
 
+	.button-wrapper.navbar-right {
+		margin-right: 0;
+	}
+
 	.button-wrapper > .navbar-time {
 		line-height: 27px;
 		color: inherit;

--- a/assets/css/_structure.less
+++ b/assets/css/_structure.less
@@ -55,9 +55,9 @@ nav {
 		}
 	}
 
-	.navbar-time {
+	.button-wrapper > .navbar-time {
 		line-height: 27px;
-		padding: 25px 15px;
+		color: inherit;
 	}
 
 	.button-wrapper > .btn {

--- a/template/assemblies/header.phtml
+++ b/template/assemblies/header.phtml
@@ -8,6 +8,11 @@
 		</div>
 
 		<div class="nav navbar-form navbar-right button-wrapper">
+			<? if(isset($room) && $room->hasSchedule()): ?>
+				<span class="navbar-text navbar-time">
+					Current Time
+				</span>
+			<? endif ?>
 			<? if(!$conference->hasEnded() && $conference->hasFeedback()): ?>
 				<a class="form-control btn btn-default feedback" title="Feedback" href="<?=h($conference->getFeedbackUrl())?>">
 					<span class="fa fa-bullhorn"></span>
@@ -22,12 +27,6 @@
 				<span class="fa fa-info"></span>
 			</a>
 		</div>
-
-		<? if(isset($room) && $room->hasSchedule()): ?>
-			<div class="navbar-right navbar-time">
-				Current Time
-			</div>
-		<? endif ?>
 	</div>
 </nav>
 

--- a/template/assemblies/header.phtml
+++ b/template/assemblies/header.phtml
@@ -7,23 +7,23 @@
 			</a>
 		</div>
 
-		<div class="nav navbar-form navbar-right button-wrapper">
+		<div class="nav navbar-right button-wrapper">
 			<? if(isset($room) && $room->hasSchedule()): ?>
 				<span class="navbar-text navbar-time">
 					Current Time
 				</span>
 			<? endif ?>
 			<? if(!$conference->hasEnded() && $conference->hasFeedback()): ?>
-				<a class="form-control btn btn-default feedback" title="Feedback" href="<?=h($conference->getFeedbackUrl())?>">
+				<a class="btn btn-default navbar-btn feedback" title="Feedback" href="<?=h($conference->getFeedbackUrl())?>">
 					<span class="fa fa-bullhorn"></span>
 				</a>
 			<? endif ?>
 			<? if($conference->hasReleases()): ?>
-				<a class="form-control btn btn-default releases" title="Releases" href="<?=h($conference->getReleasesUrl())?>">
+				<a class="btn btn-default navbar-btn releases" title="Releases" href="<?=h($conference->getReleasesUrl())?>">
 					<span class="fa fa-video-camera"></span>
 				</a>
 			<? endif ?>
-			<a class="form-control btn btn-default about" title="About" href="<?=$conference->getAboutLink()?>">
+			<a class="btn btn-default navbar-btn about" title="About" href="<?=$conference->getAboutLink()?>">
 				<span class="fa fa-info"></span>
 			</a>
 		</div>


### PR DESCRIPTION
This moves the markup for the current time display inside the same element as the navigation buttons, which prevents it from being moved to a separate row on narrow displays, which in turn resulted in 'hidden' page elements as was noted in e.g. #141 (for DiVOC R2R) and IRC (for rC3 2021).