### PR TITLE
Feature: Config per JSON anstatt PHP

### DIFF
--- a/model/Room.php
+++ b/model/Room.php
@@ -2,6 +2,7 @@
 
 class Room
 {
+	private $guid;
 	private $slug;
 	private $conference;
 	private $talks;
@@ -17,6 +18,7 @@ class Room
 			throw new NotFoundException('Room '.$slug);
 
 		$this->slug = $slug;
+		$this->guid = $this->get('GUID');
 
 		$schedule = $conference->getSchedule();
 		$talksPerRoom = $schedule->getSchedule();
@@ -41,6 +43,10 @@ class Room
 
 	public function getConference() {
 		return $this->conference;
+	}
+
+	public function getId() {
+		return $this->guid;
 	}
 
 	public function getSlug() {

--- a/model/Schedule.php
+++ b/model/Schedule.php
@@ -349,12 +349,8 @@ class Schedule
 		$mapping = array();
 		foreach($this->getConference()->get('ROOMS') as $slug => $room)
 		{
-			if(isset($room['SCHEDULE_NAME']))
-				$mapping[ $room['SCHEDULE_NAME'] ] = $slug;
-			else if(isset($room['DISPLAY']))
-				$mapping[ $room['DISPLAY'] ] = $slug;
-			else
-				$mapping[ $slug ] = $slug;
+			$key = @$room['name'] ?: @$room['SCHEDULE_NAME'] ?: @$room['DISPLAY'] ?: $slug; 
+			$this->mapping[$key] = $slug;
 		}
 
 		return $mapping;


### PR DESCRIPTION
Dieser PR ermöglich die Configuration eines Mandanten (aka Conference) zusätzlich per JSON anstatt nur per PHP. 

Man zum einen im Ordner `configs/<mandant>/` neben einer `config.php` auch eine `config.json` hinterlegen, die dann auch Vorrang gegenüber der `config.php` hat. Um Redundanzen und c&p zu vermeiden wurden außerdem einige Defaults angepasst, so das z.B. für die letzte DiVOC folgende Config reicht:

_[Nachtrag: Inzwischen ist selbst die Config für die Startseite (unten als `overviewPage` bezeichnet) optional und wird einfach mit allen Räumen der Konferenz gefüllt sofern man die nicht nochmal extra gruppieren will]_

```json
{
    "$schema": "../../../docs/config-schema.json",
    "conference": {
        "title": "DiVOC - Bridging Bubbles",
        "acronym": "divoc",
        "organizer": "DiVOC",
        "description": "Livestream des Digital verteilten Online-Chaos",
        "start": "2022-04-15T10:00:00+00:00",
        "end":   "2022-04-18T02:50:00+00:00",
        "streamingConfig": {
            "features": {
                "embed": true,
                "relive": true,
                "feedback": true,
                "chat": {
                    "hashtag": "#divocbb3",
                    "irc": {
                        "display": "#divoc @ hackint",
                        "url": "https://webirc.hackint.org/#irc://irc.hackint.org/#divoc"
                    },
                    "twitter": {
                        "display": "#divocbb3 @ twitter",
                        "text": "#divocbb3"
                    }
                }
            },
            "schedule": {
                "url": "https://pretalx.c3voc.de/divoc-bb3/schedule/export/schedule.xml",
                "scale": 7
            },
            "overviewPage": {
                "sections": [{
                    "title": "Live",
                    "items": [
                        {"type": "room", "slug": "bb3"}
                    ]
                }]
            },
            "html": {
                "banner": null,
                "footer": "\n\t\tby <a href=\"https://di.c3voc.de\">DiVOC Organizers</a> &\n\t\t<a href=\"https://c3voc.de\">C3VOC</a>\n\t",
                "not_started": null
            }
        },
        "keywords": [
            "DiVOC",
            "Hacking",
            "Chaos Computer Club",
            "Video",
            "Music",
            "Podcast",
            "Media",
            "Streaming",
            "Hacker",
            "Everywhere",
            "Bridging Bubbles",
            "bb3",
            "Ukraine",
            "Peace"
        ],
        "rooms": [
            {
                "name": "Mainstream",
                "slug": "bb3",
                "streamId": "csh",
                "streamingConfig": {
                    "translation": [
                        {"endpoint": "translated", "label": "Translated"}
                    ]
                }
            }
        ]
    }
}
```
Dadurch das im Header auch ein SchemaJSON hinterlegt ist sollte euer Editor (wie z.B. VSCode) auch direkt auto-complete Features anbieten.

Zusätzlich enthält der PR auch schon etwas Vorarbeit für einen Mechanismus der die Config in Zukunft auch von der data.c3voc.de API (aka c3data API) abruft, sofern die Streaming-Webseite den Conference-Slug nicht kennt. Ich plane aktuell allerdings nicht dieses Feature produktiv für die `jev22` einzusetzen.