### PR TITLE
Feature: Config per JSON anstatt PHP

### DIFF
--- a/command/download.php
+++ b/command/download.php
@@ -164,38 +164,3 @@ function download($what, $url, $cache)
 	}
 	return true;
 }
-
-function do_download($url, $cache)
-{
-	$handle = curl_init($url);
-	curl_setopt_array($handle, [
-		CURLOPT_FOLLOWLOCATION  => true,
-		CURLOPT_MAXREDIRS       => 10,
-		CURLOPT_RETURNTRANSFER  => true,
-		CURLOPT_SSL_VERIFYPEER  => false, /* accept all certificates, even self-signed */
-		CURLOPT_SSL_VERIFYHOST  => 2,     /* verify hostname is in cert */
-		CURLOPT_CONNECTTIMEOUT  => 3,     /* connect-timeout in seconds */
-		CURLOPT_TIMEOUT         => 5,     /* transfer timeout im seconds */
-		CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-		CURLOPT_USERAGENT       => '@c3voc Streaming-Website Downloader-Cronjob, Contact voc AT c3voc DOT de in case of problems. Might the Winkekatze be with you',
-	]);
-
-	$return = curl_exec($handle);
-	$info = curl_getinfo($handle);
-	curl_close($handle);
-
-	if($info['http_code'] != 200)
-		return 'http-code = '.$info['http_code'];
-
-	$tempfile = tempnam(dirname($cache), 'dl-');
-	if(!$tempfile)
-		return 'could not create tempfile in '.dirname($cache);
-
-	if(false === file_put_contents($tempfile, $return))
-		return 'could write data into tempfile '.$tempfile;
-
-	chmod($tempfile, 0644);
-	rename($tempfile, $cache);
-
-	return true;
-}

--- a/config.php
+++ b/config.php
@@ -56,7 +56,7 @@ $GLOBALS['CONFIG']['DOWNLOAD'] = [
 
 	/**
 	 * Nur Dateien von Konferenzen herunterladen, die weniger als
-	 * diese Aanzahl von Tagen alt sind (gemessen am END_DATE)
+	 * diese Anzahl von Tagen alt sind (gemessen am END_DATE)
 	 *
 	 * Auskommentieren, um alle Konferenzen zu beachten
 	 */
@@ -64,3 +64,194 @@ $GLOBALS['CONFIG']['DOWNLOAD'] = [
 ];
 
 $GLOBALS['CONFIG']['CDN'] = "cdn.c3voc.de";
+/**
+ * Konfiguration der Room-Defaults
+ *
+ * Falls in der Raum-Konfiguration innerhalb der Konferenz für diese Keys nichts definiert ist, 
+ * fällt das System auf diese Werte zurück.
+ */
+
+$GLOBALS['CONFIG']['ROOM_DEFAULTS'] = array(
+	'WIDE' => true,
+
+	/**
+	 * Stream-Vorschaubildchen auf der Übersichtsseite anzeigen
+	 * Damit das funktioniert muss der entsprechende runit-Task auf dem
+	 * CDN-Quell-Host (live.ber) laufen.
+	 */
+	'PREVIEW' => true,
+
+	/**
+	 * Übersetzungstonspur aktivieren
+	 *
+	 * Wenn diese Zeile auskommentiert oder auf false gesetzt ist werden nur
+	 * die native-Streams verwendet, andernfalls wird native und translated
+	 * angeboten und auch für beide Tonspuren eine Player-Seite angezeigt.
+	 *
+	 * Betrifft video sd / hd, slides, audio
+	 *
+	 * Ein Label für die Übersetzung oder mehrere Übersetzungsspuren können
+	 * wie folgt konfiguriert werden:
+	 *
+	 * 'TRANSLATION' => [
+	 *    ['endpoint' => 'translated',   'label' => 'Translated1'],
+	 *    ['endpoint' => 'translated-2', 'label' => 'Translated2']
+	 * ],
+	 *
+	 * Ein einfaches true entspricht dabei folgendem:
+	 *
+	 * 'TRANSLATION' => [
+	 *   ['endpoint' => 'translated', 'label' => 'Translated']
+	 * ],
+	 *
+	 * Sollte die Sprache während der Veranstaltung Konstant sein, kann ein
+	 * Label auch spezifisch konfiguriert werden z.B. 'label' => 'English'.
+	 */
+	/*
+	'TRANSLATION' => [
+		['endpoint' => 'translated',   'label' => 'Translated1'],
+		['endpoint' => 'translated-2', 'label' => 'Translated2']
+	],
+	*/
+
+	'STEREO' => false,
+
+	/**
+	 * SD-Video-Stream (1024×576) verfügbar
+	 *
+	 * Wenn diese Zeile auskommentiert oder auf false gesetzt ist ẃird kein SD-Video
+	 * angeboten. Wird auch HD_VIDEO auf false gesetzt oder auskommentiert ist, wird
+	 * für diesen Raum überhaupt kein Video angeboten.
+	 *
+	 * In diesem Fall wird, sofern jeweils aktiviert, Slides, Audio und zuletzt Musik
+	 * als Default-Stream angenommen.
+	 */
+	'SD_VIDEO' => true,
+
+	/**
+	 * HD-Video-Stream (1920×1080) verfügbar
+	 *
+	 * Wenn diese Zeile auskommentiert oder auf false gesetzt ist ẃird kein HD-Video
+	 * angeboten. Wird auch SD_VIDEO auf false gesetzt oder auskommentiert ist, wird
+	 * für diesen Raum überhaupt kein Video angeboten.
+	 *
+	 * In diesem Fall wird, sofern jeweils aktiviert, Slides, Audio und zuletzt Musik
+	 * als Default-Stream angenommen.
+	 */
+	'HD_VIDEO' => true,
+	'DASH' => true,
+	'H264_ONLY' => true,
+
+	/**
+	 * Slide-Only-Stream (1024×576) verfügbar
+	 *
+	 * Wenn diese Zeile auskommentiert oder auf false gesetzt ist ẃird kein Slide-Only-
+	 * Stream angeboten. Für diesen Raum wird dann keim Slides-Tab angeboten.
+	 *
+	 * In diesem Fall wird, sofern jeweils aktiviert, Audio und zuletzt Musik als
+	 * Default-Stream angenommen.
+	 */
+	'SLIDES' => false,
+
+	/**
+	 * Audio-Only-Stream verfügbar
+	 *
+	 * Wenn diese Zeile auskommentiert oder auf false gesetzt ist ẃird kein Audio-Only-
+	 * Stream angeboten. Für diesen Raum wird dann keim Audio-Tab angeboten.
+	 *
+	 * In diesem Fall wird, sofern aktiviert, Musik als Default-Stream angenommen.
+	 */
+	'AUDIO' => true,
+
+	/**
+	 * Musik-Stream verfügbar
+	 *
+	 * Wenn diese Zeile auskommentiert oder auf false gesetzt ist ẃird kein Musik-Stream
+	 * angeboten. Für diesen Raum wird dann keim Musik-Tab angeboten.
+	 *
+	 * Ist kein einziger Stream angebote, wird statt der Stream-Seite ein 404-Fehler
+	 * angezeigt.
+	 */
+	'MUSIC' => false,
+
+	/**
+	 * Fahrplan-Ansicht auf der Raum-Seite aktivieren (boolean)
+	 *
+	 * Wenn diese Zeile auskommentiert oder auf false gesetzt ist,
+	 * wird der Raum nicht im Fahrplan gesucht und auch auf der Startseite
+	 * findet keine Darstellung statt.
+	 *
+	 * Ebenso können alle Fahrplan-Funktionialitäten durch auskommentieren
+	 * des $CONFIG['SCHEDULE']-Blocks in der Konferenz Config deaktiviert werden
+	 */
+	'SCHEDULE' => true,
+
+	/**
+	 * Feedback anzeigen (boolean)
+	 *
+	 * Wenn diese Zeile auskommentiert oder auf false gesetzt ist,
+	 * taucht der Raum auch im globalen Feedback-Formular nicht auf.
+	 *
+	 * Ebenso können alle Feedback-Funktionialitäten durch auskommentieren
+	 * des $CONFIG['FEEDBACK']-Blocks deaktiviert werden
+	 */
+	'FEEDBACK' => true,
+
+	/**
+	 * Subtitles-Player aktivieren (boolean)
+	 *
+	 * Wenn diese Zeile auskommentiert oder auf false gesetzt ist,
+	 * wird der Subtitles-Button und die damit verbundenen Funktionen deaktiviert.
+	 *
+	 * Ebenso können alle Subtitles-Funktionialitäten durch auskommentieren
+	 * des $CONFIG['SUBTITLES']-Blocks deaktiviert werden
+	 */
+	'SUBTITLES' => false,
+
+	/**
+	 * Embed-Form aktivieren (boolean)
+	 *
+	 * Ist dieses Feld auf true gesetzt, wird ein Embed-Tab unter dem Video
+	 * angezeigt. Darüber kann der Player als iframe eingebunden werden.
+	 *
+	 * Wenn diese Zeile auskommentiert oder auf false gesetzt ist,
+	 * wird kein Embed-Tab angeboten und die URL zum Einbetten existiert nicht.
+	 *
+	 * Ebenso können alle Embedding-Funktionialitäten durch auskommentieren
+	 * des $CONFIG['EMBED']-Blocks in der Konferenz Config deaktiviert werden
+	 */
+	'EMBED' => true,
+
+	/**
+	 * IRC-Link aktivieren (boolean)
+	 *
+	 * Solange Twitter oder IRC aktiviert ist, wird ein "Chat"-Tab mit den
+	 * jeweiligen Links angezeigt.
+	 *
+	 * Ist dieses Feld auf true gesetzt, wird ein irc://-Link angezeigt.
+	 * WebIrc wird nach dem Congress nicht mehr unterstützt ;)
+	 *
+	 * Wenn diese Zeile auskommentiert oder auf false gesetzt ist,
+	 * wird kein IRC-Link angezeigt
+	 *
+	 * Ebenso können alle IRC-Links durch auskommentieren
+	 * des $CONFIG['IRC']-Blocks in der Konferenz Config deaktiviert werden
+	 */
+	'IRC' => true,
+
+	/**
+	 * Twitter-Link aktivieren (boolean)
+	 *
+	 * Ist dieses Feld auf true gesetzt, wird ein Link zu Twitter angezeigt.
+	 *
+	 * Solange Twitter oder IRC aktiviert ist, wird ein "Chat"-Tab mit den
+	 * jeweiligen Links angezeigt.
+	 *
+	 * Wenn diese Zeile auskommentiert oder auf false gesetzt ist,
+	 * wird kein Twitter-Link angezeigt
+	 *
+	 * Ebenso können alle Twitter-Links durch auskommentieren
+	 * des $CONFIG['TWITTER']-Blocks deaktiviert werden
+	 **/
+	'TWITTER' => true,
+);

--- a/config.php
+++ b/config.php
@@ -64,6 +64,37 @@ $GLOBALS['CONFIG']['DOWNLOAD'] = [
 ];
 
 $GLOBALS['CONFIG']['CDN'] = "cdn.c3voc.de";
+
+/**
+ * Konfiguration des Feedback-Formulars
+ *
+ * Wird dieser Block auskommentiert, wird das gesamte Feedback-System deaktiviert
+ */
+$GLOBALS['CONFIG']['FEEDBACK'] = array(
+	/**
+	 * DSN zum abspeichern der eingegebenen Daten
+	 * die Datenbank muss eine Tabelle enthaltem, die dem in `lib/schema.sql` angegebenen
+	 * Schema entspricht.
+	 *
+	 * Achtung vor Dateirechten: Bei SQLite reicht es nicht, wenn wer Webseiten-Benutzer
+	 * die .sqlite3-Datei schreiben darf, er muss auch im übergeordneten Order neue
+	 * (Lock-)Dateien anlegen dürfen
+	 */
+	'DSN' => 'sqlite:/opt/streaming-feedback/feedback.sqlite3',
+
+	/**
+	 * Login-Daten für die /feedback/read/-Seite, auf der eingegangenes
+	 * Feedback gelesen werden kann.
+	 *
+	 * Durch auskommentieren der beiden Optionen wird diese Seite komplett deaktiviert,
+	 * es kann dann nur noch durch manuelle Inspektion der .sqlite3-Datei auf das Feedback
+	 * zugegriffen werden.
+	 */
+	'USERNAME' => 'katze',
+	'PASSWORD' => trim(@file_get_contents('/opt/streaming-feedback/feedback-password')),
+);
+
+
 /**
  * Konfiguration der Room-Defaults
  *

--- a/configs/archive/divoc2022/config.json
+++ b/configs/archive/divoc2022/config.json
@@ -1,0 +1,75 @@
+{
+    "$schema": "../../../docs/config-schema.json",
+    "conference": {
+        "title": "DiVOC - Bridging Bubbles",
+        "acronym": "divoc",
+        "organizer": "DiVOC",
+        "description": "Livestream des Digital verteilten Online-Chaos",
+        "start": "2022-04-15T10:00:00+00:00",
+        "end":   "2022-04-18T02:50:00+00:00",
+        "streamingConfig": {
+            "features": {
+                "embed": true,
+                "relive": true,
+                "feedback": true,
+                "chat": {
+                    "hashtag": "#divocbb3",
+                    "irc": {
+                        "display": "#divoc @ hackint",
+                        "url": "https://webirc.hackint.org/#irc://irc.hackint.org/#divoc"
+                    },
+                    "twitter": {
+                        "display": "#divocbb3 @ twitter",
+                        "text": "#divocbb3"
+                    }
+                }
+            },
+            "schedule": {
+                "url": "https://pretalx.c3voc.de/divoc-bb3/schedule/export/schedule.xml",
+                "scale": 7
+            },
+            "overviewPage": {
+                "sections": [{
+                    "title": "Live",
+                    "items": [
+                        {"slug": "bb3"}
+                    ]
+                }]
+            },
+            "html": {
+                "banner": null,
+                "footer": "\n\t\tby <a href=\"https://di.c3voc.de\">DiVOC Organizers</a> &\n\t\t<a href=\"https://c3voc.de\">C3VOC</a>\n\t",
+                "not_started": null
+            }
+        },
+        "keywords": [
+            "DiVOC",
+            "Hacking",
+            "Chaos Computer Club",
+            "Video",
+            "Music",
+            "Podcast",
+            "Media",
+            "Streaming",
+            "Hacker",
+            "Everywhere",
+            "Bridging Bubbles",
+            "bb3",
+            "Ukraine",
+            "Peace"
+        ],
+        "rooms": [
+            {
+                "name": "Mainstream",
+                "slug": "bb3",
+                "streamId": "csh",
+                "streamingConfig": {
+                    "feedback": true,
+                    "translation": [
+                        {"endpoint": "translated", "label": "Translated"}
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/configs/archive/divoc2022/config.php
+++ b/configs/archive/divoc2022/config.php
@@ -331,7 +331,7 @@ $CONFIG['TWITTER'] = array(
 
 
 
-/**
+/*
 $CONFIG['EXTRA_FILES'] = array(
 	'schedule.xml'  => 'https://pretalx.c3voc.de/divoc-bb3/schedule/export/schedule.xml',
 	'schedule.json' => 'https://pretalx.c3voc.de/divoc-bb3/schedule/export/schedule.json',

--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -98,55 +98,54 @@
           "items": {
             "type": "string"
           }
+        },
+        "streamingConfig": {
+          "$ref": "#/definitions/StreamingConfig"
+        },
+        "rooms": {
+          "type": "array",
+          "title": "Räume",
+          "description": "(= Audio & Video Produktionen, also auch DJ-Sets o.ä.)",
+          "default": [],
+          "additionalItems": true,
+          "items": {
+            "anyOf": [
+              {
+                "type": "object",
+                "default": {},
+                "required": ["name", "slug", "streamId", "streamingConfig"],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Raum Name",
+                    "description": "(aus Schedule)",
+                    "default": "",
+                    "examples": ["Piscopia"]
+                  },
+                  "slug": {
+                    "type": "string",
+                    "title": "Raum-Slug",
+                    "description": "Wird in den URLs oder im Feedback verwendet",
+                    "default": "",
+                    "examples": ["halla", "vortrag", "piscopia"]
+                  },
+                  "streamId": {
+                    "type": "string",
+                    "title": "Stream ID",
+                    "description": "Der Name des Kanals im VOC Streaming CDN z.B. s1",
+                    "default": "",
+                    "examples": ["s1", "s2", "s3", "s4", "q1", "divoc", "cccb"]
+                  },
+                  "streamingConfig": {
+                    "$ref": "#/definitions/RoomStreamingConfig"
+                  }
+                }
+              }
+            ]
+          }
         }
       }
-    },
-    "rooms": {
-      "type": "array",
-      "title": "Räume",
-      "description": "(= Audio & Video Produktionen, also auch DJ-Sets o.ä.)",
-      "default": [],
-      "additionalItems": true,
-      "items": {
-        "anyOf": [
-          {
-            "type": "object",
-            "default": {},
-            "required": ["name", "slug", "streamId", "streamingConfig"],
-            "properties": {
-              "name": {
-                "type": "string",
-                "title": "Raum Name",
-                "description": "(aus Schedule)",
-                "default": "",
-                "examples": ["Piscopia"]
-              },
-              "slug": {
-                "type": "string",
-                "title": "Raum-Slug",
-                "description": "Wird in den URLs oder im Feedback verwendet",
-                "default": "",
-                "examples": ["halla", "vortrag", "piscopia"]
-              },
-              "streamId": {
-                "type": "string",
-                "title": "Stream ID",
-                "description": "Der Name des Kanals im VOC Streaming CDN z.B. s1",
-                "default": "",
-                "examples": ["s1", "s2", "s3", "s4", "q1", "divoc", "cccb"]
-              },
-              "streamingConfig": {
-                "$ref": "#/definitions/RoomStreamingConfig"
-              }
-            }
-          }
-        ]
-      }
-    },
-    "streamingConfig": {
-      "$ref": "#/definitions/StreamingConfig"
     }
-  
   },
   "definitions": {
     "Room": {
@@ -200,7 +199,7 @@
             "hashtag": {
               "type": "string",
               "title": "Hashtag der Konferenz",
-              "examples": ["#36C3", "#divoc-r2r"]
+              "examples": ["#36C3", "#divocr2r"]
             },
             "twitter": {
               "type": ["boolean", "object"]
@@ -321,7 +320,7 @@
           }
         },
         "extraFiles": {
-          "type": "object",
+          "type": ["object", "null"],
           "additionalProperties": true
         }
       }
@@ -335,7 +334,6 @@
         {
           "schedule_name": "Piscopia",
           "display": "Piscopia",
-          "stream": "divocr2r",
           "preview": true,
           "stereo": false,
           "sd_video": true,
@@ -345,7 +343,6 @@
           "audio": true
         }
       ],
-      "required": ["display", "stream", "preview", "slides", "schedule"],
       "properties": {
         "display": {
           "type": "string",

--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -150,7 +150,7 @@
   "definitions": {
     "Room": {
       "type": "object",
-      "description": "Liste der Räume (= Audio & Video Produktionen, also auch DJ-Sets o.ä.)",
+      "description": "Liste der Räume/Streams/Channels (= Audio & Video Produktionen, also auch DJ-Sets o.ä.)",
       "additionalProperties": false,
       "properties": {
         "name": {
@@ -166,7 +166,7 @@
           "$ref": "#/definitions/RoomStreamingConfig"
         }
       },
-      "required": ["streamId", "name", "slug", "streamingConfig"]
+      "required": ["streamId", "name", "slug"]
     },
     "Features": {
       "type": "object",
@@ -208,7 +208,8 @@
               "type": "boolean"
             },
             "matrix": {
-              "type": "boolean"
+              "$ref": "#/definitions/IrcConfig",
+              "type": ["object", "boolean"]
             },
             "irc": {
               "$ref": "#/definitions/IrcConfig",
@@ -238,7 +239,7 @@
       "title": "Konfigurationen",
       "description": "",
       "default": {},
-      "required": ["features", "overviewPage"],
+      "required": ["features"],
       "properties": {
         "schedule": {
           "type": "object",
@@ -356,8 +357,8 @@
         },
         "wide": {
           "type": "boolean",
-          "title": "16:9",
-          "description": "",
+          "title": "Breiter Teaser",
+          "description": "Doppelte Breite für die Teaserbox auf der Übersichtsseite",
           "default": true
         },
         "preview": {
@@ -474,21 +475,21 @@
         }
       }
     },
-    "ChatConfig": {
+    "ChatConfig":{
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "irc": {
-
+        "matrix": {
+          "$ref": "#/definitions/IrcConfig"
         },
-        "twitter": {
-
+        "irc": {
+          "$ref": "#/definitions/IrcConfig"
         },
         "mastodon":{
-
+          "$ref": "#/definitions/SocialMediaConfig"
         },
-        "matrix": {
-
+        "twitter": {
+          "$ref": "#/definitions/SocialMediaConfig"
         }
       }
     },
@@ -507,8 +508,8 @@
       },
       "required": ["display", "url"]
     },
-    "TwitterConfig": {
-      "title": "Twitter",
+    "SocialMediaConfig": {
+      "title": "SocialMedia",
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/index.php
+++ b/index.php
@@ -15,8 +15,10 @@ require_once('lib/Exceptions.php');
 require_once('lib/less.php/Less.php');
 
 require_once('model/ModelBase.php');
+require_once('model/ModelJson.php');
 require_once('model/Conferences.php');
 require_once('model/Conference.php');
+require_once('model/ConferenceJson.php');
 require_once('model/GenericConference.php');
 require_once('model/Feedback.php');
 require_once('model/Schedule.php');

--- a/index.php
+++ b/index.php
@@ -159,7 +159,7 @@ try {
 			exit;
 		}
 	}
-	else if(!Conferences::exists($mandator))
+	else if(false && !Conferences::exists($mandator))
 	{
 		// old url OR wrong client OR
 		// -> error

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -172,3 +172,66 @@ function slugify($text)
 
 	return $text;
 }
+
+function do_download($url, $cache, $return_response = false)
+{
+	$handle = curl_init($url);
+	curl_setopt_array($handle, [
+		CURLOPT_FOLLOWLOCATION  => true,
+		CURLOPT_MAXREDIRS       => 10,
+		CURLOPT_RETURNTRANSFER  => true,
+		CURLOPT_SSL_VERIFYPEER  => false, /* accept all certificates, even self-signed */
+		CURLOPT_SSL_VERIFYHOST  => 2,     /* verify hostname is in cert */
+		CURLOPT_CONNECTTIMEOUT  => 3,     /* connect-timeout in seconds */
+		CURLOPT_TIMEOUT         => 5,     /* transfer timeout im seconds */
+		CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+		CURLOPT_USERAGENT       => '@c3voc Streaming-Website Downloader-Cronjob, Contact voc AT c3voc DOT de in case of problems. Might the Winkekatze be with you',
+	]);
+
+	$return = curl_exec($handle);
+	$info = curl_getinfo($handle);
+	curl_close($handle);
+
+	// TODO: should we add proper exceptions?
+	if($info['http_code'] != 200)
+		return 'http-code = '.$info['http_code'];
+
+	$tempfile = tempnam(dirname($cache), 'dl-');
+	if(!$tempfile)
+		return 'could not create tempfile in '.dirname($cache);
+
+	if(false === file_put_contents($tempfile, $return))
+		return 'could write data into tempfile '.$tempfile;
+
+	chmod($tempfile, 0644);
+	rename($tempfile, $cache);
+
+	return $return_response ? $return : true;
+}
+
+
+// specifies the number of seconds after which data will be refreshed
+static $cache_lifetime	= 300; // 5min
+$check_time = time() - $cache_lifetime;
+
+function query_data($operation, $query, $variables = [], $assoc = false, $cache = null) {
+	global $check_time;
+
+	$cache = $cache ?: joinpath([$GLOBALS['BASEDIR'], 'cache', $operation, http_build_query($variables) . '.json']);
+
+	if (file_exists($cache) && filemtime($cache) > $check_time) {
+		$res = file_get_contents($cache);
+	} else {
+		$url = 'https://data.c3voc.de/graphql?variables=' .json_encode($variables) . '&query=' . urlencode(preg_replace('/\s\s+/', ' ', $query));
+		$res = do_download($url, $cache, true);
+	}
+	$r = json_decode($res, $assoc);
+
+	if (is_null($r)) {
+		throw new NotFoundException();
+	}
+
+	// TODO: add error handling?
+	// TODO: should we return the cached value, when we did not get an answer? 
+	return $assoc ? @$r['data'] : @$r->data;
+}

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -173,6 +173,17 @@ function slugify($text)
 	return $text;
 }
 
+
+/**
+ * From https://stackoverflow.com/a/10252511/319266
+ * @param string $str
+ * @return string
+ */
+function strip_comments($str) {
+	return preg_replace('![ \t]+//.*[ \t]*[\r\n]!', '', $str);
+}
+
+
 function do_download($url, $cache, $return_response = false)
 {
 	$handle = curl_init($url);

--- a/model/Conference.php
+++ b/model/Conference.php
@@ -3,6 +3,7 @@
 class Conference extends ModelBase
 {
 	private $slug;
+	private $schedule;
 
 	public function __construct($config, $slug)
 	{
@@ -227,7 +228,11 @@ class Conference extends ModelBase
 		return new Feedback($this);
 	}
 	public function getSchedule() {
-		return new Schedule($this);
+		if (!isset($this->schedule)) {
+			return $this->schedule = new Schedule($this);
+		}
+
+		return $this->schedule;
 	}
 	public function getSubtitles() {
 		return new Subtitles($this);

--- a/model/Conference.php
+++ b/model/Conference.php
@@ -162,7 +162,7 @@ class Conference extends ModelBase
 	}
 
 	public function hasFeedback() {
-		return $this->has('FEEDBACK');
+		return $this->has('FEEDBACK') && $this->get('FEEDBACK') !== false;
 	}
 	public function getFeedbackUrl() {
 		return joinpath([$this->getSlug(), 'feedback']).url_params();

--- a/model/ConferenceJson.php
+++ b/model/ConferenceJson.php
@@ -1,0 +1,133 @@
+<?php
+
+class ConferenceJson extends Conference
+{
+	private $start;
+	private $end;
+	private $rooms;
+
+	public function __construct($json, $mandator)
+	{
+		$c = $json->conference;
+		$this->start = DateTime::createFromFormat('c', @$c->start ?: @$c->startDate);
+		$this->end =   DateTime::createFromFormat('c', @$c->end   ?: @$c->endDate);
+	
+		$groups = [];
+		// if ( $c->streamingConfig->overviewPage->sections )
+		foreach(@$c->streamingConfig->overviewPage->sections as $s) {
+			$groups[@$s->title] = array_map(
+				function($r) { return $r->slug; }, 
+				@$s->items ?: @$s->rooms ?: []
+			);
+		}
+
+		$this->rooms = [];
+		$rooms = @$c->rooms->nodes ?: $c->rooms;
+		foreach($rooms as $r) {
+			$this->rooms[$r->slug] = array_merge(
+				get_object_vars($r), 
+				@get_object_vars($r->streamingConfig) ?: [], 
+				@get_object_vars($r->streamingConfig->chat) ?: []
+			);
+		}
+		parent::__construct([
+			'conference' => array_merge([
+				'title' 		=> $c->title,
+				'author' 		=> $c->organizer,
+				'description' 	=> $c->description,
+				'keywords'		=> @implode(', ', $c->keywords),
+			], @get_object_vars($c->streamingConfig) ?: []),
+
+			'rooms' => $this->rooms,
+
+			'overview' => [
+				'groups' => $groups
+			]
+
+		], $mandator ?: $c->acronym);
+	}
+
+	public function has($keychain)
+	{
+		return ModelJson::_has($this->config, $keychain);
+	}
+
+	public function get($keychain, $default = null)
+	{
+		return ModelJson::_get($this->config, $keychain, $default);
+	}
+
+	/*
+	public function getTitle() {
+		return $this->data->conference->title;
+	}
+
+	public function hasAuthor() {
+		return !empty($this->data->conference->organizer);
+	}
+	public function getAuthor() {
+		return $this->data->conference->organizer ?: '';
+	}
+	*/
+
+	public function startsAt() {
+		return $this->start;
+	}
+
+	public function endsAt() {
+		return $this->end;
+	}
+
+	public function hasEnded() {
+		// on the preview-domain no conference ever ends
+		if($this->isPreviewEnabled())
+			return false;
+
+		if($this->has('CONFERENCE.CLOSED')) {
+			$closed = $this->get('CONFERENCE.CLOSED');
+
+			if($closed == "after" || $closed === true)
+				return true;
+			else if($closed == "running" || $closed == "before" ||
+				$closed === false)
+				return false;
+		}
+
+		if($this->end) {
+			$now = new DateTime('now');
+			return $now >= $this->end;
+		} else {
+			return false;
+		}
+	}
+
+	public function getRooms()
+	{
+		$rooms = array();
+		foreach($this->rooms as $slug => $room)
+			$rooms[] = $this->getRoom($slug);
+
+		return $rooms;
+	}
+
+	public function getRoomIfExists($room)
+	{
+		if($this->hasRoom($room))
+			return $this->getRoom($room);
+
+		return null;
+	}
+
+	public function hasRoom($slug)
+	{
+		return array_key_exists($slug, $this->rooms);
+	}
+
+	public function getRoom($slug) {
+		return new Room($this, $slug);
+	}
+
+	public function hasFeedback() {
+		return $this->has('FEEDBACK');
+	}
+}

--- a/model/ConferenceJson.php
+++ b/model/ConferenceJson.php
@@ -5,13 +5,15 @@ class ConferenceJson extends Conference
 	private $start;
 	private $end;
 	private $rooms;
+	private $html;
 
 	public function __construct($json, $mandator)
 	{
 		$c = $json->conference;
 		$this->start = DateTime::createFromFormat('c', @$c->start ?: @$c->startDate);
-		$this->end =   DateTime::createFromFormat('c', @$c->end   ?: @$c->endDate);
-	
+		$this->end   = DateTime::createFromFormat('c', @$c->end   ?: @$c->endDate);
+		$this->html  = @$c->streamingConfig->html ?: [];
+
 		$groups = [];
 		// if ( $c->streamingConfig->overviewPage->sections )
 		foreach(@$c->streamingConfig->overviewPage->sections as $s) {
@@ -36,7 +38,8 @@ class ConferenceJson extends Conference
 				'author' 		=> $c->organizer,
 				'description' 	=> $c->description,
 				'keywords'		=> @implode(', ', $c->keywords),
-			], @get_object_vars($c->streamingConfig) ?: []),
+			], 
+			@get_object_vars($c->streamingConfig) ?: []),
 
 			'rooms' => $this->rooms,
 
@@ -130,4 +133,26 @@ class ConferenceJson extends Conference
 	public function hasFeedback() {
 		return $this->has('FEEDBACK');
 	}
+
+	public function hasBannerHtml() {
+		return array_key_exists('banner', $this->html) && !empty($this->html->banner);
+	}
+	public function getBannerHtml() {
+		return $this->html->banner;
+	}
+
+	public function hasFooterHtml() {
+		return array_key_exists('footer', $this->html) && !empty($this->html->footer);
+	}
+	public function getFooterHtml() {
+		return $this->html->footer;
+	}
+
+	public function hasNotStartedHtml() {
+		return array_key_exists('not_started', $this->html);
+	}
+	public function getNotStartedHtml() {
+		return $this->html->not_started;
+	}
+
 }

--- a/model/Conferences.php
+++ b/model/Conferences.php
@@ -107,7 +107,8 @@ class Conferences
 		if (file_exists($configfile)) {
 
 			$data = file_get_contents($configfile); 
-			$config = json_decode($data);
+			$config = json_decode(strip_comments($data));
+			
 			
 			if(is_null($config)) {
 				throw new ConfigException("Loading $configfile did not return an object. Maybe it's not a real JSON file?" . json_last_error_msg());

--- a/model/Conferences.php
+++ b/model/Conferences.php
@@ -143,7 +143,9 @@ class Conferences
 				endDate
 				streamingConfig 
 				
-				rooms(orderBy: [RANK_ASC, NAME_ASC], filter: {streamId: {isNull: false}}) {
+				rooms(orderBy: [RANK_ASC, NAME_ASC]' . ( 
+					false ? ', filter: {streamId: {isNull: false}}' : '' 
+				) . ' ) {
 					nodes {
 						guid
 						name

--- a/model/Conferences.php
+++ b/model/Conferences.php
@@ -111,7 +111,7 @@ class Conferences
 			
 			
 			if(is_null($config)) {
-				throw new ConfigException("Loading $configfile did not return an object. Maybe it's not a real JSON file?" . json_last_error_msg());
+				throw new ConfigException("Loading $configfile did not return an object. Maybe it's not a real JSON file? \n" . json_last_error_msg());
 			}
 
 			return new ConferenceJson($config, $mandator);
@@ -140,12 +140,12 @@ class Conferences
 				description
 				keywords
 				organizer
-				startDate
-				endDate
+				start: startDate
+				end: endDate
 				streamingConfig 
 				
 				rooms(orderBy: [RANK_ASC, NAME_ASC]' . ( 
-					false ? ', filter: {streamId: {isNull: false}}' : '' 
+					true ? ', filter: {streamId: {isNull: false}}' : '' 
 				) . ' ) {
 					nodes {
 						guid

--- a/model/Feedback.php
+++ b/model/Feedback.php
@@ -9,6 +9,12 @@ class Feedback
 		$this->conference = $conference;
 	}
 
+	private function get($key) {
+		return $this->conference->has(['FEEDBACK', $key])
+			? $this->conference->get(['FEEDBACK', $key])
+			: @$GLOBALS['CONFIG']['FEEDBACK'][$key];
+	}
+
 	public function getConference() {
 		return $this->conference;
 	}
@@ -27,7 +33,7 @@ class Feedback
 
 	public function store($info)
 	{
-		$db = new PDO($this->getConference()->get('FEEDBACK.DSN'));
+		$db = new PDO($this->get('DSN'));
 		$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 		$stm = $db->prepare('
@@ -56,8 +62,8 @@ class Feedback
 	{
 		return
 			isset($_SERVER['PHP_AUTH_USER']) &&
-			$_SERVER['PHP_AUTH_USER'] == $this->getConference()->get('FEEDBACK.USERNAME') &&
-			$_SERVER['PHP_AUTH_PW'] == $this->getConference()->get('FEEDBACK.PASSWORD');
+			$_SERVER['PHP_AUTH_USER'] == $this->get('USERNAME') &&
+			$_SERVER['PHP_AUTH_PW'] == $this->get('PASSWORD');
 	}
 
 	public function requestLogin()
@@ -70,12 +76,12 @@ class Feedback
 
 	public function read($from, $to)
 	{
-		$db = new PDO($this->getConference()->get('FEEDBACK.DSN'));
+		$db = new PDO($this->get('DSN'));
 		$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 		$stm = $db->prepare('
 			SELECT *
-			  FROM feedback
+			 FROM feedback
 			 WHERE reported BETWEEN :from AND :to
 			 ORDER BY reported DESC
 		');

--- a/model/ModelJson.php
+++ b/model/ModelJson.php
@@ -1,0 +1,50 @@
+<?php
+
+class ModelJson
+{
+	protected $config;
+	public function __construct($config)
+	{
+		$this->config = $config;
+	}
+
+	public function has($keychain)
+	{
+		return ModelJson::_has($this->config, $keychain);
+	}
+
+	public static function _has($array, $keychain)
+	{
+		if(!is_array($keychain))
+			$keychain = explode('.', $keychain);
+
+		$key = strtolower($keychain[0]);
+		if(!isset($array[$key]))
+			return false;
+
+		if(count($keychain) == 1)
+			return true;
+
+		return ModelJson::_has($array[$key], array_slice($keychain, 1));
+	}
+
+	public function get($keychain, $default = null)
+	{
+		return ModelJson::_get($this->config, $keychain, $default);
+	}
+
+	public static function _get($array, $keychain, $default)
+	{
+		if(!is_array($keychain))
+			$keychain = explode('.', $keychain);
+
+		$key = strtolower($keychain[0]);
+		if(!isset($array[$key]))
+			return $default;
+
+		if(count($keychain) == 1)
+			return $array[$key];
+
+		return ModelJson::_get($array[$key], array_slice($keychain, 1), $default);
+	}
+}

--- a/model/ModelJson.php
+++ b/model/ModelJson.php
@@ -13,19 +13,20 @@ class ModelJson
 		return ModelJson::_has($this->config, $keychain);
 	}
 
-	public static function _has($array, $keychain)
+	public static function _has($model, $keychain)
 	{
 		if(!is_array($keychain))
 			$keychain = explode('.', $keychain);
 
 		$key = strtolower($keychain[0]);
-		if(!isset($array[$key]))
+		if(is_array($model) ? !isset($model[$key]) : !isset($model->$key))
 			return false;
 
 		if(count($keychain) == 1)
 			return true;
 
-		return ModelJson::_has($array[$key], array_slice($keychain, 1));
+		$value = is_array($model) ? $model[$key] : $model->$key;
+		return ModelJson::_has($value, array_slice($keychain, 1));
 	}
 
 	public function get($keychain, $default = null)
@@ -33,18 +34,19 @@ class ModelJson
 		return ModelJson::_get($this->config, $keychain, $default);
 	}
 
-	public static function _get($array, $keychain, $default)
+	public static function _get($model, $keychain, $default)
 	{
 		if(!is_array($keychain))
 			$keychain = explode('.', $keychain);
 
 		$key = strtolower($keychain[0]);
-		if(!isset($array[$key]))
+		if (is_array($model) ? !isset($model[$key]) : !isset($model->$key))
 			return $default;
 
+		$value = is_array($model) ? $model[$key] : $model->$key;
 		if(count($keychain) == 1)
-			return $array[$key];
+			return $value;
 
-		return ModelJson::_get($array[$key], array_slice($keychain, 1), $default);
+		return ModelJson::_get($value, array_slice($keychain, 1), $default);
 	}
 }

--- a/model/Room.php
+++ b/model/Room.php
@@ -47,6 +47,15 @@ class Room
 		return $this->slug;
 	}
 
+	private function get($key, $fallbackValue = null) {
+		$keychain = 'ROOMS.'.$this->getSlug().'.'.$key;
+		return $this->conference->get($keychain, $fallbackValue ?: @$GLOBALS['CONFIG']['ROOM_DEFAULTS'][$key]);
+	}
+
+	private function has($key) {
+		return $this->conference->has('ROOMS.'.$this->getSlug().'.'.$key);
+	}
+
 	public function getThumb() {
 		return proto().'://'.joinpath([$GLOBALS['CONFIG']['CDN'], 'thumbnail', $this->getStream(), 'thumb.jpeg']);
 	}
@@ -60,19 +69,19 @@ class Room
 	}
 
 	public function getStream() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.STREAM', $this->getSlug());
+		return $this->get('STREAM') ?: $this->get('streamId') ?: $this->getSlug();
 	}
 
 	public function getScheduleName() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.SCHEDULE_NAME', $this->getDisplay());
+		return $this->get('SCHEDULE_NAME', $this->getDisplay());
 	}
 
 	public function getDisplay() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.DISPLAY', $this->getSlug());
+		return $this->get('DISPLAY') ?: $this->get('name') ?: $this->getSlug();
 	}
 
 	public function getDisplayShort() {
-		$display_short = $this->getConference()->get('ROOMS.'.$this->getSlug().'.DISPLAY_SHORT', '');
+		$display_short = $this->get('DISPLAY_SHORT', '');
 		if (empty($display_short)) {
 			return $this->getDisplay(); // getDisplay() falls back to slug
 		}
@@ -82,49 +91,47 @@ class Room
 	}
 
 	public function h264Only() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.H264_ONLY', false);
+		return $this->get('H264_ONLY');
 	}
 
-
-
 	public function hasStereo() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.STEREO');
+		return $this->get('STEREO');
 	}
 
 	public function hasPreview() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.PREVIEW');
+		return $this->get('PREVIEW');
 	}
 
 	public function requestsWide() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.WIDE');
+		return $this->get('WIDE');
 	}
 
 	public function hasSchedule() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.SCHEDULE') && $this->getConference()->has('SCHEDULE');
+		return $this->get('SCHEDULE') && $this->getConference()->has('SCHEDULE');
 	}
 
 	public function hasSubtitles() {
 		return
-			$this->getConference()->get('ROOMS.'.$this->getSlug().'.SUBTITLES') &&
-			$this->getConference()->has('ROOMS.'.$this->getSlug().'.SUBTITLES_ROOM_ID') &&
+			$this->get('SUBTITLES') &&
+			$this->has('SUBTITLES_ROOM_ID') &&
 			$this->getConference()->has('SUBTITLES');
 	}
 	public function getSubtitlesRoomId() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.SUBTITLES_ROOM_ID');
+		return $this->get('SUBTITLES_ROOM_ID');
 	}
 
 	public function hasFeedback() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.FEEDBACK') && $this->getConference()->has('FEEDBACK');
+		return $this->get('FEEDBACK') && $this->getConference()->has('FEEDBACK');
 	}
 
 
 	public function hasTwitter() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.TWITTER') && $this->getConference()->has('TWITTER');
+		return $this->get('TWITTER') && $this->getConference()->has('TWITTER');
 	}
 
 	public function getTwitterDisplay() {
 		return sprintf(
-			$this->getConference()->get('ROOMS.'.$this->getSlug().'.TWITTER_CONFIG.DISPLAY', $this->getConference()->get('TWITTER.DISPLAY')),
+			$this->get('TWITTER_CONFIG.DISPLAY', $this->getConference()->get('TWITTER.DISPLAY')),
 			$this->getSlug()
 		);
 	}
@@ -138,37 +145,37 @@ class Room
 
 	public function getTwitterText() {
 		return sprintf(
-			$this->getConference()->get('ROOMS.'.$this->getSlug().'.TWITTER_CONFIG.TEXT', $this->getConference()->get('TWITTER.TEXT')),
+			$this->get('TWITTER_CONFIG.TEXT', $this->getConference()->get('TWITTER.TEXT')),
 			$this->getSlug()
 		);
 	}
 
 
 	public function hasIrc() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.IRC') && $this->getConference()->has('IRC');
+		return $this->get('IRC') && $this->getConference()->has('IRC');
 	}
 
 	public function getIrcDisplay() {
 		return sprintf(
-			$this->getConference()->get('ROOMS.'.$this->getSlug().'.IRC_CONFIG.DISPLAY', $this->getConference()->get('IRC.DISPLAY')),
+			$this->get('IRC_CONFIG.DISPLAY', $this->getConference()->get('IRC.DISPLAY')),
 			$this->getSlug()
 		);
 	}
 
 	public function getIrcUrl() {
 		return sprintf(
-			$this->getConference()->get('ROOMS.'.$this->getSlug().'.IRC_CONFIG.URL', $this->getConference()->get('IRC.URL')),
+			$this->get('IRC_CONFIG.URL', $this->getConference()->get('IRC.URL')),
 			rawurlencode($this->getSlug())
 		);
 	}
 
 	public function hasWebchat() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.WEBCHAT') && $this->getConference()->has('WEBCHAT_URL');
+		return $this->get('WEBCHAT') && $this->getConference()->has('WEBCHAT_URL');
 	}
 
 	public function getWebchatUrl() {
 		return sprintf(
-			$this->getConference()->get('ROOMS.'.$this->getSlug().'.WEBCHAT_URL', $this->getConference()->get('WEBCHAT_URL')),
+			$this->get('WEBCHAT_URL', $this->getConference()->get('WEBCHAT_URL')),
 			rawurlencode($this->getSlug())
 		);
 	}
@@ -179,39 +186,39 @@ class Room
 
 
 	public function hasEmbed() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.EMBED') && $this->getConference()->get('EMBED');
+		return $this->get('EMBED') && $this->getConference()->get('EMBED');
 	}
 
 	public function hasInfo() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.INFO') && $this->getConference()->get('INFO');
+		return $this->get('INFO') && $this->getConference()->get('INFO');
 	}
 
 	public function getInfo() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.INFO');
+		return $this->get('INFO');
 	}
 	
 	public function hasSdVideo() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.SD_VIDEO');
+		return $this->get('SD_VIDEO');
 	}
 
 	public function hasHdVideo() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.HD_VIDEO');
+		return $this->get('HD_VIDEO');
 	}
 
 	public function hasAudio() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.AUDIO');
+		return $this->get('AUDIO');
 	}
 
 	public function hasSlides() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.SLIDES');
+		return $this->get('SLIDES');
 	}
 
 	public function hasMusic() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.MUSIC');
+		return $this->get('MUSIC');
 	}
 
 	public function hasDash() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.DASH');
+		return $this->get('DASH');
 	}
 
 	public function getHLSPlaylistUrl() {
@@ -227,7 +234,7 @@ class Room
 	}
 
 	public function getTranslations() {
-		return $this->getConference()->get('ROOMS.'.$this->getSlug().'.TRANSLATION');
+		return $this->get('TRANSLATION');
 	}
 
 	private function getTranslationEndpoints() {

--- a/model/Room.php
+++ b/model/Room.php
@@ -73,7 +73,7 @@ class Room
 	}
 
 	public function getScheduleName() {
-		return $this->get('SCHEDULE_NAME', $this->getDisplay());
+		return $this->get('SCHEDULE_NAME') ?: $this->get('name') ?: $this->getDisplay();
 	}
 
 	public function getDisplay() {
@@ -99,7 +99,7 @@ class Room
 	}
 
 	public function hasPreview() {
-		return $this->get('PREVIEW');
+		return $this->get('PREVIEW', true);
 	}
 
 	public function requestsWide() {
@@ -107,7 +107,7 @@ class Room
 	}
 
 	public function hasSchedule() {
-		return $this->get('SCHEDULE') && $this->getConference()->has('SCHEDULE');
+		return $this->get('SCHEDULE', true) && $this->getConference()->has('SCHEDULE');
 	}
 
 	public function hasSubtitles() {
@@ -218,7 +218,7 @@ class Room
 	}
 
 	public function hasDash() {
-		return $this->get('DASH');
+		return $this->get('DASH', true);
 	}
 
 	public function getHLSPlaylistUrl() {
@@ -234,7 +234,7 @@ class Room
 	}
 
 	public function getTranslations() {
-		return $this->get('TRANSLATION');
+		return $this->get('TRANSLATION') ?: [];
 	}
 
 	private function getTranslationEndpoints() {

--- a/model/Room.php
+++ b/model/Room.php
@@ -2,6 +2,7 @@
 
 class Room
 {
+	private $guid;
 	private $slug;
 	private $conference;
 	private $talks;
@@ -17,6 +18,7 @@ class Room
 			throw new NotFoundException('Room '.$slug);
 
 		$this->slug = $slug;
+		$this->guid = $this->get('GUID');
 
 		$schedule = $conference->getSchedule();
 		$talksPerRoom = $schedule->getSchedule();
@@ -41,6 +43,10 @@ class Room
 
 	public function getConference() {
 		return $this->conference;
+	}
+
+	public function getId() {
+		return $this->guid;
 	}
 
 	public function getSlug() {

--- a/model/Schedule.php
+++ b/model/Schedule.php
@@ -3,6 +3,7 @@
 class Schedule
 {
 	private $conference;
+	private $program;
 
 	public function __construct($conference)
 	{
@@ -70,8 +71,23 @@ class Schedule
 		return simplexml_load_string($schedule);
 	}
 
+	public function getRoomSchedule($roomName, $roomGuid) {
+
+		// build program, if not realy set
+		if (!isset($this->program)) {
+			$this->getSchedule();
+		}
+
+		return $this->program[$roomName];
+	}
+
 	public function getSchedule()
 	{
+		// reusue already computed schedule, if set.
+		if (isset($this->program)) {
+			return $this->program;
+		}
+
 		// download schedule-xml
 		$schedule = $this->fetchSchedule();
 
@@ -267,8 +283,9 @@ class Schedule
 				return array_search($a, $roomfilter) - array_search($b, $roomfilter);
 			});
 		}
+		$this->program = $program;
 
-		return $program;
+		return $this->program;
 	}
 
 	private function makeEvent(DateTimeImmutable $from, DateTimeImmutable $to): array {

--- a/model/Schedule.php
+++ b/model/Schedule.php
@@ -349,12 +349,8 @@ class Schedule
 		$mapping = array();
 		foreach($this->getConference()->get('ROOMS') as $slug => $room)
 		{
-			if(isset($room['SCHEDULE_NAME']))
-				$mapping[ $room['SCHEDULE_NAME'] ] = $slug;
-			else if(isset($room['DISPLAY']))
-				$mapping[ $room['DISPLAY'] ] = $slug;
-			else
-				$mapping[ $slug ] = $slug;
+			$key = @$room['name'] ?: @$room['SCHEDULE_NAME'] ?: @$room['DISPLAY'] ?: $slug; 
+			$this->mapping[$key] = $slug;
 		}
 
 		return $mapping;

--- a/serve.sh
+++ b/serve.sh
@@ -26,4 +26,4 @@ if [ -z "$(find "configs/upcoming.json" -newermt "8 hours ago")" ]; then
 	echo
 fi
 
-$php_bin -S localhost:$port -d short_open_tag=true index.php
+$php_bin -S localhost:$port -d short_open_tag=true $2 index.php

--- a/view/config-json.php
+++ b/view/config-json.php
@@ -19,8 +19,10 @@ function formatConference($conference) {
 					'embed' => $conference->get('EMBED', false),
 					'relive' => $conference->hasRelive(),
 					'feedback' => $conference->hasFeedback(),
-					'irc' => lowerCaseKeys($conference->get('IRC', false)),
-					'twitter' => lowerCaseKeys($conference->get('TWITTER', false)),
+					'chat' => array(
+						'irc' => lowerCaseKeys($conference->get('IRC', false)),
+						'twitter' => lowerCaseKeys($conference->get('TWITTER', false)),
+					),
 				),
 				'schedule' => lowerCaseKeys($conference->get('SCHEDULE')),
 				'overviewPage' => array(
@@ -56,17 +58,17 @@ function formatRooms($conference) {
 function formatSections($pageConfig) {
 	$struct = [];
 
-	foreach($pageConfig as $sectionTitle => $rooms)
+	foreach($pageConfig as $sectionTitle => $items)
 	{
 		$section = array(
 			'title' => $sectionTitle,
-			'rooms' => [], 
+			'items' => [], 
 		);
 
-		foreach($rooms as $room)
+		foreach($items as $item)
 		{
-			$section['rooms'][] = array(
-				'slug' => $room,
+			$section['items'][] = array(
+				'slug' => $item,
 			);
 		}
 		$struct[] = $section;

--- a/view/config-json.php
+++ b/view/config-json.php
@@ -20,8 +20,8 @@ function formatConference($conference) {
 					'relive' => $conference->hasRelive(),
 					'feedback' => $conference->hasFeedback(),
 					'chat' => array(
-						'irc' => lowerCaseKeys($conference->get('IRC', false)),
-						'twitter' => lowerCaseKeys($conference->get('TWITTER', false)),
+						'irc' => lowerCaseKeys($conference->get('IRC', null)),
+						'twitter' => lowerCaseKeys($conference->get('TWITTER', null)),
 					),
 				),
 				'schedule' => lowerCaseKeys($conference->get('SCHEDULE')),
@@ -48,8 +48,8 @@ function formatRooms($conference) {
 		$struct[] = array(
 			'name' => $room->getDisplay(),
 			'slug' => $room->getSlug(),
-			'streamId' => $room->getStream(),
-			'streamingConfig' => lowerCaseKeys($config),
+			'stream' => $room->getStream(),
+			'streamingConfig' => $config ? lowerCaseKeys($config) : null,
 		);
 	}
 	return $struct;
@@ -78,6 +78,9 @@ function formatSections($pageConfig) {
 
 function lowerCaseKeys($config)
 {
+	if (empty($config)) {
+		return null;
+	}
 	return array_map(function($item) {
 		return is_array($item) ? lowerCaseKeys($item) : $item;
 	}, array_change_key_case($config));


### PR DESCRIPTION
Dieser PR ermöglich die Configuration eines Mandanten (aka Conference) zusätzlich per JSON anstatt nur per PHP. 

Man zum einen im Ordner `configs/<mandant>/` neben einer `config.php` auch eine `config.json` hinterlegen, die dann auch Vorrang gegenüber der `config.php` hat. Um Redundanzen und c&p zu vermeiden wurden außerdem einige Defaults angepasst, so das z.B. für die letzte DiVOC folgende Config reicht:

_[Nachtrag: Inzwischen ist selbst die Config für die Startseite (unten als `overviewPage` bezeichnet) optional und wird einfach mit allen Räumen der Konferenz gefüllt sofern man die nicht nochmal extra gruppieren will]_

```json
{
    "$schema": "../../../docs/config-schema.json",
    "conference": {
        "title": "DiVOC - Bridging Bubbles",
        "acronym": "divoc",
        "organizer": "DiVOC",
        "description": "Livestream des Digital verteilten Online-Chaos",
        "start": "2022-04-15T10:00:00+00:00",
        "end":   "2022-04-18T02:50:00+00:00",
        "streamingConfig": {
            "features": {
                "embed": true,
                "relive": true,
                "feedback": true,
                "chat": {
                    "hashtag": "#divocbb3",
                    "irc": {
                        "display": "#divoc @ hackint",
                        "url": "https://webirc.hackint.org/#irc://irc.hackint.org/#divoc"
                    },
                    "twitter": {
                        "display": "#divocbb3 @ twitter",
                        "text": "#divocbb3"
                    }
                }
            },
            "schedule": {
                "url": "https://pretalx.c3voc.de/divoc-bb3/schedule/export/schedule.xml",
                "scale": 7
            },
            "overviewPage": {
                "sections": [{
                    "title": "Live",
                    "items": [
                        {"type": "room", "slug": "bb3"}
                    ]
                }]
            },
            "html": {
                "banner": null,
                "footer": "\n\t\tby <a href=\"https://di.c3voc.de\">DiVOC Organizers</a> &\n\t\t<a href=\"https://c3voc.de\">C3VOC</a>\n\t",
                "not_started": null
            }
        },
        "keywords": [
            "DiVOC",
            "Hacking",
            "Chaos Computer Club",
            "Video",
            "Music",
            "Podcast",
            "Media",
            "Streaming",
            "Hacker",
            "Everywhere",
            "Bridging Bubbles",
            "bb3",
            "Ukraine",
            "Peace"
        ],
        "rooms": [
            {
                "name": "Mainstream",
                "slug": "bb3",
                "streamId": "csh",
                "streamingConfig": {
                    "translation": [
                        {"endpoint": "translated", "label": "Translated"}
                    ]
                }
            }
        ]
    }
}
```
Dadurch das im Header auch ein SchemaJSON hinterlegt ist sollte euer Editor (wie z.B. VSCode) auch direkt auto-complete Features anbieten.

Zusätzlich enthält der PR auch schon etwas Vorarbeit für einen Mechanismus der die Config in Zukunft auch von der data.c3voc.de API (aka c3data API) abruft, sofern die Streaming-Webseite den Conference-Slug nicht kennt. Ich plane aktuell allerdings nicht dieses Feature produktiv für die `jev22` einzusetzen.