### PR TITLE
jev22: configure Reconnect to Chaos (RTC22)

### DIFF
--- a/configs/conferences/jev22/config.json
+++ b/configs/conferences/jev22/config.json
@@ -58,7 +58,17 @@
         "streamId": "s4",
         "streamingConfig": {
           "chat": {
-            "hashtag": "#rtc22"
+            "hashtag": "#rtc22",
+            "mastodon": true,
+            "twitter": true,
+            "matrix": {
+              "display": "#rtc22-stream:chat.ccc-p.org",
+              "url": "https://matrix.to/#/#rtc22-stream:chat.ccc-p.org"
+            },
+            "irc": {
+              "display": "#rtc22 @ hackint",
+              "url": "https://webirc.hackint.org/#ircs://irc.hackint.org/#rtc22"
+            }
           }
         }
       },

--- a/configs/conferences/jev22/config.json
+++ b/configs/conferences/jev22/config.json
@@ -58,6 +58,8 @@
         "streamId": "s4",
         "streamingConfig": {
           "chat": {
+            "display": "Reconnect to Chaos",
+            "display_short": "RTC",
             "hashtag": "#rtc22",
             "mastodon": true,
             "twitter": true,


### PR DESCRIPTION
Configure RTC room:
- stream Q&A channel on matrix and IRC (they are bridged into each other)
- Social media (Twitter, Mastodon)


~~TODO:~~ Also done:
Make sure that we have "Reconnect to Chaos" and RTC/RTC22 branding for streaming. "Sparti" is only relevant for the physical location mostly, not for the streaming event. We probably need to set `display` and `display_short` in the `streamingConfig` for this.