### PR TITLE
PHP 8: Fix major compatibility issues

### DIFF
--- a/config.php
+++ b/config.php
@@ -24,11 +24,11 @@ $GLOBALS['CONFIG']['PREVIEW_DOMAIN'] = 'xlocalhost';
  * Protokollfreie URLs (welche, die mit // beginnen), werden automatisch mit dem korrekten Protokoll ergänzt.
  * In diesem Fall wird auch ein SSL-Umschalt-Button im Header angezeigt
  */
-if(@$_SERVER['SERVER_NAME'] == 'localhost' || @$_SERVER['SERVER_NAME'] == '0.0.0.0')
+if(isset($_SERVER['SERVER_NAME']) && ($_SERVER['SERVER_NAME'] == 'localhost' || $_SERVER['SERVER_NAME'] == '0.0.0.0'))
 {
 	// keine Konfiguration -> BASEURL wird automatisch erraten
 }
-else if(@$_SERVER['SERVER_NAME'] == 'streaming.test.c3voc.de')
+else if(isset($_SERVER['SERVER_NAME']) && ($_SERVER['SERVER_NAME'] == 'streaming.test.c3voc.de'))
 {
 	$GLOBALS['CONFIG']['BASEURL'] = '//streaming.test.c3voc.de/';
 }
@@ -104,7 +104,7 @@ $GLOBALS['CONFIG']['FEEDBACK'] = array(
 /**
  * Konfiguration der Room-Defaults
  *
- * Falls in der Raum-Konfiguration innerhalb der Konferenz für diese Keys nichts definiert ist, 
+ * Falls in der Raum-Konfiguration innerhalb der Konferenz für diese Keys nichts definiert ist,
  * fällt das System auf diese Werte zurück.
  */
 

--- a/index.php
+++ b/index.php
@@ -87,7 +87,7 @@ try {
 		'conference' => new GenericConference(),
 	));
 
-	if(startswith('//', @$GLOBALS['CONFIG']['BASEURL']))
+	if(isset($GLOBALS['CONFIG']['BASEURL']) && startswith('//', @$GLOBALS['CONFIG']['BASEURL']))
 	{
 		$tpl->set(array(
 			'httpsurl' => forceslash(forceslash('https:'.$GLOBALS['CONFIG']['BASEURL']).@$GLOBALS['MANDATOR']).forceslash($route).url_params(),
@@ -128,7 +128,7 @@ try {
 		exit;
 	}
 
-	@list($mandator, $route) = explode('/', $route, 2);
+	list($mandator, $route) = array_pad(explode('/', $route, 2), 2, "");
 	if(!$mandator)
 	{
 		// root requested

--- a/index.php
+++ b/index.php
@@ -52,11 +52,11 @@ if(isset($argv) && isset($argv[1]))
 try {
 	if(isset($_GET['htaccess']))
 	{
-		$route = @$_GET['route'];
+		$route = isset($_GET['route']) ? $_GET['route'] : "";
 	}
 	elseif(isset($_SERVER["REQUEST_URI"]))
 	{
-		$route = ltrim(@$_SERVER["REQUEST_URI"], '/');
+		$route = ltrim($_SERVER["REQUEST_URI"], '/');
 
 		// serve static
 		if($route != '' && file_exists($_SERVER["DOCUMENT_ROOT"].'/'.$route))
@@ -87,11 +87,12 @@ try {
 		'conference' => new GenericConference(),
 	));
 
-	if(isset($GLOBALS['CONFIG']['BASEURL']) && startswith('//', @$GLOBALS['CONFIG']['BASEURL']))
+	if(isset($GLOBALS['CONFIG']['BASEURL']) && startswith('//', $GLOBALS['CONFIG']['BASEURL']))
 	{
+		$mandator = isset($GLOBALS['MANDATOR']) ? $GLOBALS['MANDATOR'] : "";
 		$tpl->set(array(
-			'httpsurl' => forceslash(forceslash('https:'.$GLOBALS['CONFIG']['BASEURL']).@$GLOBALS['MANDATOR']).forceslash($route).url_params(),
-			'httpurl' =>  forceslash(forceslash('http:'. $GLOBALS['CONFIG']['BASEURL']).@$GLOBALS['MANDATOR']).forceslash($route).url_params(),
+			'httpsurl' => forceslash(forceslash('https:'.$GLOBALS['CONFIG']['BASEURL']).$mandator).forceslash($route).url_params(),
+			'httpurl' =>  forceslash(forceslash('http:'. $GLOBALS['CONFIG']['BASEURL']).$mandator).forceslash($route).url_params(),
 		));
 	}
 

--- a/lib/PhpTemplate.php
+++ b/lib/PhpTemplate.php
@@ -13,10 +13,12 @@ if(!function_exists('h'))
 class PhpTemplate
 {
 	private $data = array();
+	public $file;
 
 	public function __construct($file)
 	{
 		$this->file = $file;
+		$this->data["naked"] = false;
 	}
 
 	public function set($___data = array())

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -244,8 +244,20 @@ function query_data($operation, $query, $variables = [], $assoc = false, $cache 
 	if (is_null($r)) {
 		throw new NotFoundException();
 	}
-
+	
 	// TODO: add error handling?
 	// TODO: should we return the cached value, when we did not get an answer? 
-	return $assoc ? @$r['data'] : @$r->data;
+	if ($assoc) {
+		if (isset($r['data'])) {
+			return $r['data'];
+		} else {
+			throw new NotFoundException();
+		}
+	} else {
+		if (isset($r->data)) {
+			return $r->data;
+		} else {
+			throw new NotFoundException();
+		}
+	}
 }

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -36,6 +36,9 @@ function joinpath($parts)
 
 function forceslash($url)
 {
+	if ($url == NULL) {
+		$url = "";
+	}
 	$url =  rtrim($url, '/');
 	if(strlen($url) > 0)
 		$url .= '/';

--- a/lib/less.php/Less.php
+++ b/lib/less.php/Less.php
@@ -4748,6 +4748,7 @@ class Less_Tree_Call extends Less_Tree{
     protected $index;
     protected $currentFileInfo;
     public $type = 'Call';
+		public $parensInOp;
 
 	public function __construct($name, $args, $index, $currentFileInfo = null ){
 		$this->name = $name;
@@ -5291,6 +5292,7 @@ class Less_Tree_Dimension extends Less_Tree{
 	public $value;
 	public $unit;
 	public $type = 'Dimension';
+	public $parensInOp;
 
     public function __construct($value, $unit = null){
         $this->value = floatval($value);
@@ -5497,6 +5499,8 @@ class Less_Tree_Directive extends Less_Tree{
 	public $currentFileInfo;
 	public $debugInfo;
 	public $type = 'Directive';
+	public $parensInOp;
+	public $allExtends;
 
 	public function __construct($name, $value, $rules, $index = null, $currentFileInfo = null, $debugInfo = null ){
 		$this->name = $name;
@@ -6224,6 +6228,7 @@ class Less_Tree_Media extends Less_Tree{
 	public $currentFileInfo;
 	public $isReferenced;
 	public $type = 'Media';
+	public $allExtends;
 
 	public function __construct($value = array(), $features = array(), $index = null, $currentFileInfo = null ){
 
@@ -6478,6 +6483,7 @@ class Less_Tree_Operation extends Less_Tree{
 	public $operands;
 	public $isSpaced;
 	public $type = 'Operation';
+	public $parensInOp;
 
 	/**
 	 * @param string $op
@@ -6669,6 +6675,7 @@ class Less_Tree_Rule extends Less_Tree{
 	public $variable;
 	public $currentFileInfo;
 	public $type = 'Rule';
+	public $extendOnEveryPath;
 
 	/**
 	 * @param string $important
@@ -6795,6 +6802,7 @@ class Less_Tree_Ruleset extends Less_Tree{
 	public $originalRuleset;
 
 	public $first_oelements;
+	public $extendOnEveryPath;
 
 	public function SetRulesetIndex(){
 		$this->ruleset_id = Less_Parser::$next_id++;
@@ -7951,6 +7959,7 @@ class Less_Tree_Variable extends Less_Tree{
 	public $currentFileInfo;
 	public $evaluating = false;
 	public $type = 'Variable';
+	public $parensInOp;
 
     /**
      * @param string $name

--- a/model/Conference.php
+++ b/model/Conference.php
@@ -20,7 +20,7 @@ class Conference extends ModelBase
 	}
 
 	public function isPreviewEnabled() {
-		if(@$GLOBALS['forceopen'])
+		if(isset($GLOBALS['forceopen']) && $GLOBALS['forceopen'])
 			return true;
 
 		if($this->has('PREVIEW_DOMAIN') && ($this->get('PREVIEW_DOMAIN') == $_SERVER['SERVER_NAME']))

--- a/model/Conferences.php
+++ b/model/Conferences.php
@@ -65,7 +65,8 @@ class Conferences
 	}
 
 	public static function getLastConference() {
-		return @Conferences::getFinishedConferencesSorted()[0];
+		$conferences = Conferences::getFinishedConferencesSorted();
+		return isset($conferences[0]) ? $conferences[0] : null;
 	}
 
 	public static function exists($mandator) {
@@ -133,7 +134,7 @@ class Conferences
 		}
 
 		// config option for dynamic lookup feature defined below
-		if (!@$GLOBALS['CONFIG']['DYNAMIC_LOOKUP']) {
+		if (isset($GLOBALS['CONFIG']['DYNAMIC_LOOKUP']) && !$GLOBALS['CONFIG']['DYNAMIC_LOOKUP']) {
 			throw new NotFoundException();;
 		}
 

--- a/model/Feedback.php
+++ b/model/Feedback.php
@@ -10,9 +10,10 @@ class Feedback
 	}
 
 	private function get($key) {
+		$global_feedback_elem = isset($GLOBALS['CONFIG']['FEEDBACK'][$key]) ? $GLOBALS['CONFIG']['FEEDBACK'][$key] : "";
 		return $this->conference->has(['FEEDBACK', $key])
 			? $this->conference->get(['FEEDBACK', $key])
-			: @$GLOBALS['CONFIG']['FEEDBACK'][$key];
+			: $global_feedback_elem;
 	}
 
 	public function getConference() {

--- a/model/Overview.php
+++ b/model/Overview.php
@@ -2,6 +2,8 @@
 
 class Overview
 {
+	public $conference;
+
 	public function __construct(Conference $conference)
 	{
 		$this->conference = $conference;

--- a/model/Room.php
+++ b/model/Room.php
@@ -50,12 +50,20 @@ class Room
 	}
 
 	public function getSlug() {
-		return $this->slug;
+		if ($this->slug != NULL) {
+			return $this->slug;
+		} else {
+			return "";
+		}
 	}
 
 	private function get($key, $fallbackValue = null) {
 		$keychain = 'ROOMS.'.$this->getSlug().'.'.$key;
-		return $this->conference->get($keychain, $fallbackValue ?: @$GLOBALS['CONFIG']['ROOM_DEFAULTS'][$key]);
+		$fallback = null;
+		if (isset($GLOBALS['CONFIG']['ROOM_DEFAULTS'][$key])) {
+			$fallback = $GLOBALS['CONFIG']['ROOM_DEFAULTS'][$key];
+		}
+		return $this->conference->get($keychain, $fallbackValue ?: $fallback);
 	}
 
 	private function has($key) {

--- a/model/RoomSelection.php
+++ b/model/RoomSelection.php
@@ -2,6 +2,9 @@
 
 class RoomSelection
 {
+	public $room;
+	public $selection;
+
 	public function __construct(Room $room, $selection)
 	{
 		$this->room = $room;

--- a/model/RoomTab.php
+++ b/model/RoomTab.php
@@ -2,6 +2,9 @@
 
 class RoomTab
 {
+	public $room;
+	public $tab;
+
 	public function __construct(Room $room, $tab)
 	{
 		$this->room = $room;

--- a/model/Schedule.php
+++ b/model/Schedule.php
@@ -364,7 +364,15 @@ class Schedule
 			$this->mapping = array();
 			foreach($this->getConference()->get('ROOMS') as $slug => $room)
 			{
-				$key = @$room['name'] ?: @$room['SCHEDULE_NAME'] ?: @$room['DISPLAY'] ?: $slug; 
+				// json has 'name', config.php has 'SCHEDULE_NAME' and 'DISPLAY'
+				$key = $slug;
+				if (isset($room['name'])) {
+					$key = $room['name'];
+				} elseif ($room['SCHEDULE_NAME']) {
+					$key = $room['SCHEDULE_NAME'];
+				} elseif ($room['DISPLAY']) {
+					$key = $room['DISPLAY'];
+				}
 				$this->mapping[$key] = $slug;
 			}
 		}

--- a/model/Schedule.php
+++ b/model/Schedule.php
@@ -54,7 +54,8 @@ class Schedule
 
 	public function getMappedRoom($scheduleRoom) {
 		$mapping = $this->getScheduleToRoomSlugMapping();
-		return $this->getConference()->getRoomIfExists( @$mapping[$scheduleRoom] );
+		$room = isset($mapping[$scheduleRoom]) ? $mapping[$scheduleRoom] : "";
+		return $this->getConference()->getRoomIfExists( $room );
 	}
 
 	public function getScheduleDisplayTime($basetime = null)
@@ -68,12 +69,16 @@ class Schedule
 
 	private function fetchSchedule()
 	{
-		$schedule = @file_get_contents($this->getScheduleCache());
-
-		if(!$schedule)
+		try {
+			$schedule = file_get_contents($this->getScheduleCache());
+	
+			if(!$schedule)
+				return null;
+	
+			return simplexml_load_string($schedule);
+		} catch (ErrorException $e) {
 			return null;
-
-		return simplexml_load_string($schedule);
+		}
 	}
 
 	public function getRoomSchedule($roomName, $roomGuid) {

--- a/model/Stream.php
+++ b/model/Stream.php
@@ -2,6 +2,11 @@
 
 class Stream
 {
+	public $room;
+	public $selection;
+	public $language;
+	public $translation_label;
+
 	public function __construct(Room $room, $selection, $language, $translation_label = null)
 	{
 		$this->room = $room;

--- a/template/assemblies/feedback.phtml
+++ b/template/assemblies/feedback.phtml
@@ -102,7 +102,7 @@
 
 		<div class="form-group">
 			<label for="datetime">Date/Time</label>
-			<input type="text" value="<?=h(strftime('%d.%m.%Y %H:%I'))?>" name="datetime" id="datetime" class="form-control" />
+			<input type="text" value="<?=h(date('d.m.Y H:i'))?>" name="datetime" id="datetime" class="form-control" />
 		</div>
 
 		<div class="form-group">

--- a/template/assemblies/schedule.phtml
+++ b/template/assemblies/schedule.phtml
@@ -25,8 +25,13 @@
 			<div class="room <? if(isset($room) && ($roomname == $room->getScheduleName() ||  ($scheduleRoom && $scheduleRoom->getId() === $room->getId()))): ?>highlight<? endif ?>" style="width: <?= h($totalWidth) ?>px">
 				<? $fromstart = 0; ?>
 				<? foreach($events as $event): ?>
+					<? $special = isset($event['special']) ? $event['special'] : ''; ?>
+					<? $event_is_optout = isset($event['optout']) ? $event['optout'] : false; ?>
+					<? $event_guid = isset($event['guid']) ? $event['guid'] : ''; ?>
+					<? $event_url = isset($event['url']) ? $event['url'] : ''; ?>
+					<? $event_title = isset($event['title']) ? $event['title'] : ''; ?>
 					<div
-						class="block <?=h(@$event['special'] ?: 'event')?> <?=h((@$event['optout']) ? 'optout' : '')?>"
+						class="block <?=h($special ?: 'event')?> <?=h($event_is_optout ? 'optout' : '')?>"
 						style="width: <?=h(round($event['duration'] / $schedule->getScale()))?>px; left: <?=h(round($fromstart / $schedule->getScale()))?>px"
 						data-start="<?=intval($event['start'])?>"
 						data-end="<?=intval($event['end'])?>"
@@ -42,21 +47,21 @@
 										href="<?=h($scheduleRoom->createTabObject()->getLink($roomname))?>"
 								<? endif ?>
 								title="Switch to <?=h($scheduleRoom->getDisplay())?>"
-								onmouseover="showEventDetails(event, {title:'<?=@$event['title']?>', guid:'<?=@$event['guid']?>', url:'<?=@$event['url']?>', type:'<?=@$event['special']?>'})"
+								onmouseover="showEventDetails(event, {title:'<?=$event_title?>', guid:'<?=$event_guid?>', url:'<?=$event_url?>', type:'<?=@$special?>'})"
 							>
 						<? else: ?>
 							<div class="inner">
 						<? endif ?>
 
-							<? if(@$event['special'] == 'daychange'): ?>
+							<? if(@$special == 'daychange'): ?>
 
 							<h3><?=h($event['title'])?></h3>
 
-							<? elseif(@$event['special'] == 'gap'): ?>
+							<? elseif(@$special == 'gap'): ?>
 
 								<!--h3>Gap</h3-->
 
-							<? elseif(@$event['special'] == 'pause'): ?>
+							<? elseif(@$special == 'pause'): ?>
 
 								<h3><?=h($event['title'])?></h3>
 
@@ -70,7 +75,7 @@
 									</h4>
 								<? endif ?>
 								<h3 title="<?=$event['title']?>">
-									<?=h($event['title'])?><? if (@$event['optout']): ?><i> (no recording)</i><? endif ?>
+									<?=h($event['title'])?><? if ($event_is_optout): ?><i> (no recording)</i><? endif ?>
 								</h3>
 								<? if(! empty(trim($event['speaker']))): ?>
 									<h5>by&nbsp;<?=h($event['speaker'])?></h5>

--- a/template/overview.phtml
+++ b/template/overview.phtml
@@ -104,14 +104,15 @@
 									$upcoming = @$upcomingTalksPerRoom[ $room->getSlug() ] ?: [];
 									// echo var_dump($upcoming);
 									$current = @$upcoming['current'];
-									$next = @$upcoming['next']; ?>
+									$next = @$upcoming['next'];
+									$next_is_special = isset($next['special']) ? $next['special'] : false; ?>
 									<div class="program-schedule">
 										<? if($current && !@$current['special']): ?>
 										<div class="talk current-talk" title="<?=h(@$current['title'] ?: 'none') ?>">
 											<strong>Now (since <?=date('G:i', @$current['start']) ?>):</strong><br/>
 											<span class="t"><?=h(@$current['title'] ?: 'none') ?></span>
 										</div>
-										<? endif; if($next && !@$next['special']): ?>
+										<? endif; if($next && !$next_is_special): ?>
 										<div class="talk next-talk" title="<?=h(@$next['title'] ?: 'none') ?>">
 											<strong>Next (<?=date('G:i', @$next['start']) ?>):</strong><br/>
 											<span class="t"><?=h(@$next['title'] ?: 'none') ?></span>

--- a/view/allclosed.php
+++ b/view/allclosed.php
@@ -6,7 +6,7 @@ echo $tpl->render(array(
 	'page' => 'allclosed',
 	'title' => 'See you soon … somewhere else!',
 
-	'next' => @$events[0],
+	'next' => isset($events[0]) ? $events[0] : null,
 	'events' => $events,
 	'last' => Conferences::getLastConference(),
 ));

--- a/view/closed.php
+++ b/view/closed.php
@@ -6,6 +6,6 @@ echo $tpl->render(array(
 	'page' => 'closed',
 	'title' => 'See you soon … somewhere else!',
 
-	'next' => @$events[0],
+	'next' => isset($events[0]) ? $events[0] : null,
 	'events' => $events,
 ));

--- a/view/embed.php
+++ b/view/embed.php
@@ -28,5 +28,5 @@ echo $tpl->render(array(
 	'room' => $room,
 	'stream' => $stream,
 
-	'autoplay' => @$_GET['autoplay'],
+	'autoplay' => isset($_GET['autoplay']) ? $_GET['autoplay'] : false,
 ));

--- a/view/multiview.php
+++ b/view/multiview.php
@@ -5,5 +5,5 @@ echo $tpl->render(array(
 	'title' => 'Stream-Übersicht',
 
 	'rooms' => $conference->getRooms(),
-	'selection' => @$_GET['selection'],
+	'selection' => isset($_GET['selection']) ? $_GET['selection'] : "",
 ));


### PR DESCRIPTION
PHP8 deprecated, that class member variables can be created outside the class definition or constructor, which prevented the code to run at all. Additionally the error handling has changed, which has lead to multiple other errors during the runtime.

Finally, strftime was deprecated in PHP 8.1.
