### PR TITLE
jugendhackt fix date/time

### DIFF
--- a/configs/conferences/jugendhackt/config.json
+++ b/configs/conferences/jugendhackt/config.json
@@ -4,8 +4,8 @@
     "description": "Jugend hackt Live Streaming, 2024 edition",
     "media_slug": "jh24",
     "organizer": "Jugend hackt",
-    "start": "2024-06-14T12:00:00+02:00",
-    "end": "2024-06-14T10:00:00+02:00",
+    "start": "2024-06-16T13:00:00+02:00",
+    "end": "2024-06-16T16:00:00+02:00",
     "title": "Jugend hackt Schweiz 2024",
     "streamingConfig": {
       "html": {


### PR DESCRIPTION
cc @Kunsi date/time of jugendhackt seems off. The presentation is tomorrow, it is supposed to start at 13:30. I guess the stream should go public at 1pm.