### PR TITLE
Jugend hackt Hamburg 2024

### DIFF
--- a/configs/conferences/jugendhackt/config.json
+++ b/configs/conferences/jugendhackt/config.json
@@ -4,8 +4,8 @@
     "description": "Jugend hackt Live Streaming, 2024 edition",
     "media_slug": "jh24",
     "organizer": "Jugend hackt",
-    "start": "2024-07-19T13:00:00+02:00",
-    "end": "2024-07-21T18:00:00+02:00",
+    "start": "2024-09-20T13:00:00+02:00",
+    "end": "2024-09-22T18:00:00+02:00",
     "title": "Jugend hackt Hamburg 2024",
     "streamingConfig": {
       "html": {

--- a/configs/conferences/jugendhackt/config.json
+++ b/configs/conferences/jugendhackt/config.json
@@ -6,7 +6,7 @@
     "organizer": "Jugend hackt",
     "start": "2024-07-19T13:00:00+02:00",
     "end": "2024-07-21T18:00:00+02:00",
-    "title": "Jugend hackt Rhein-Neckar 2024",
+    "title": "Jugend hackt Hamburg 2024",
     "streamingConfig": {
       "html": {
         "footer": "by <a href='http://jugendhackt.de/'>Jugend hackt 2024</a> &amp; <a href='https://c3voc.de'>C3VOC</a>",
@@ -15,9 +15,9 @@
     },
     "rooms": [
       {
-        "name": "Rhein-Neckar",
+        "name": "Betahaus Hamburg",
         "slug": "saal",
-        "streamId": "s96"
+        "streamId": "s1"
       }
     ]
   }


### PR DESCRIPTION
Changes Streaming Site from JH Rhein Neckar to Hamburg