### PR TITLE
jugendhackt -> luzern

### DIFF
--- a/configs/conferences/jugendhackt/config.json
+++ b/configs/conferences/jugendhackt/config.json
@@ -4,9 +4,9 @@
     "description": "Jugend hackt Live Streaming, 2024 edition",
     "media_slug": "jh24",
     "organizer": "Jugend hackt",
-    "start": "2024-10-03T13:45:00+02:00",
-    "end": "2024-10-06T17:00:00+02:00",
-    "title": "Jugend hackt Berlin 2024",
+    "start": "2024-10-13T13:00:00+02:00",
+    "end": "2024-10-13T17:00:00+02:00",
+    "title": "Jugend hackt Luzern 2024",
     "streamingConfig": {
       "html": {
         "footer": "by <a href='http://jugendhackt.de/'>Jugend hackt 2024</a> &amp; <a href='https://c3voc.de'>C3VOC</a>",
@@ -15,7 +15,7 @@
     },
     "rooms": [
       {
-        "name": "Jugendkulturzentrum Königsstadt",
+        "name": "Tüftelwerk",
         "slug": "saal",
         "streamId": "s6"
       }


### PR DESCRIPTION
Adapt streaming config for Jugendhackt Luzern (CH). Not sure what to specify for the `streamId` though.