### PR TITLE
Make schedule past readable

### DIFF
--- a/assets/css/_schedule.less
+++ b/assets/css/_schedule.less
@@ -19,6 +19,7 @@ body .schedule {
 	.now {
 		position: absolute;
 		pointer-events: none;
+		opacity: 50%;
 		height: 100%;
 		display: flex;
 		left: 0;


### PR DESCRIPTION
Changes the red rectangle that denotes how far along the schedule is semi-transparent so the things below can still be read.