### PR TITLE
disable syncing from action

### DIFF
--- a/.github/workflows/validate+sync.yml
+++ b/.github/workflows/validate+sync.yml
@@ -1,4 +1,5 @@
-name: validate & sync
+---
+name: validate
 
 on:
   workflow_dispatch:
@@ -10,43 +11,43 @@ jobs:
   lint-and-validate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: PHP Lint
-      uses: michaelw90/PHP-Lint@2.1.0
+      - name: PHP Lint
+        uses: michaelw90/PHP-Lint@2.1.0
 
-    - name: Check for any changed config.json files
-      id: check-for-changed-configs
-      uses: tj-actions/changed-files@v41
-      with:
-        files: |
-          configs/conferences/**/config.json
-    
-    - name: Validate json files
-      if: steps.check-for-changed-configs.outputs.any_changed == 'true'
-      uses: dsanders11/json-schema-validate-action@v1.2.0
-      with:
-        schema: docs/config-schema.json
-        files: configs/conferences/**/config.json 
-        options: --strict=false
+      - name: Check for any changed config.json files
+        id: check-for-changed-configs
+        uses: tj-actions/changed-files@v41
+        with:
+          files: |
+            configs/conferences/**/config.json
 
-  mirror:
-    runs-on: ubuntu-latest
-    if: ${{ github.ref != 'refs/heads/master' || (github.event_name == 'push' && contains(github.event.head_commit.message, 'Merge pull request')) }}
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - name: Validate json files
+        if: steps.check-for-changed-configs.outputs.any_changed == 'true'
+        uses: dsanders11/json-schema-validate-action@v1.2.0
+        with:
+          schema: docs/config-schema.json
+          files: configs/conferences/**/config.json
+          options: --strict=false
 
-    - name: Mirror to VOC gitolite
-      env: 
-        secrets_available:  ${{ secrets.SSH_PRIVATE_KEY }} != ''
-      if: ${{ env.secrets_available }}
-      uses: pixta-dev/repository-mirroring-action@v1.1.1
-      with:
-        target_repo_url:
-          git@git.c3voc.de:streaming-website.git
-        ssh_private_key:
-          ${{ secrets.SSH_PRIVATE_KEY }}
+#  mirror:
+#    runs-on: ubuntu-latest
+#    if: ${{ github.ref != 'refs/heads/master' || (github.event_name == 'push' && contains(github.event.head_commit.message, 'Merge pull request')) }}
+#    steps:
+#    - uses: actions/checkout@v4
+#      with:
+#        fetch-depth: 0
+#
+#    - name: Mirror to VOC gitolite
+#      env:
+#        secrets_available:  ${{ secrets.SSH_PRIVATE_KEY }} != ''
+#      if: ${{ env.secrets_available }}
+#      uses: pixta-dev/repository-mirroring-action@v1.1.1
+#      with:
+#        target_repo_url:
+#          git@git.c3voc.de:streaming-website.git
+#        ssh_private_key:
+#          ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
Hey there,

I noticed that the sync git repo action keeps failing. It looks like there is a bug with the SSH key.

Until this is fixed, I suggest you skip the failing part. So I have added comments to the action.

:dove: 